### PR TITLE
fix: tighten KNN sanity cap for low-observation skins

### DIFF
--- a/server/engine/pricing.ts
+++ b/server/engine/pricing.ts
@@ -423,12 +423,20 @@ export async function lookupOutputPrice(
 
   if (knn && knn.confidence >= 0.3) {
     grossPrice = knn.priceCents;
-    // Sanity cap: if KNN is >5x condition-level ref, KNN is probably wrong
-    // (pattern premiums, Skinport platform bias, sparse-data interpolation artifacts).
-    // 98.5% of real sales are within 2x ref; >5x are pattern items KNN can't price.
+    // Observation-count-dependent sanity cap: low-count KNN (especially Tier 2
+    // interpolation between 2 points) is unreliable for pattern-based skins where
+    // a single rare-pattern sale can 5-10x the normal price. Scale the cap:
+    //   ≤3 obs → 2x ref (sparse data, interpolation is noise)
+    //   4-5 obs → 3x ref (thin data, MAD clamping has marginal effect)
+    //   6+ obs  → 5x ref (enough data for KNN to be meaningful)
     const refPrice = lookupPrice(pool, skinName, predictedFloat);
-    if (refPrice > 0 && grossPrice > refPrice * 5) {
-      grossPrice = refPrice;
+    if (refPrice > 0) {
+      const maxMultiplier = knn.observationCount <= 3 ? 2.0
+        : knn.observationCount <= 5 ? 3.0
+        : 5.0;
+      if (grossPrice > refPrice * maxMultiplier) {
+        grossPrice = refPrice;
+      }
     }
   } else {
     // 2. Fallback: condition-level pricing from csfloat_ref + listing floors


### PR DESCRIPTION
## Summary
- Pattern-based skins (Crimson Kimono, Case Hardened) with very few sale observations had wildly inflated output prices
- Root cause: KNN Tier 2 interpolation between 2 observations ($5k normal + $20k pattern sale) → ~$18k estimate, and the flat 5x sanity cap didn't catch it
- Fix: scale the sanity cap by observation count (≤3 obs → 2x, 4-5 → 3x, 6+ → 5x existing behavior)
- Verified against production DB: fixes 2 overpriced skins (Crimson Kimono MW, Karambit CH FT), doesn't affect 11 other low-data skins or any well-observed skins

## Test plan
- [x] 58 pricing unit tests pass
- [x] 531 total tests pass (pre-push hook)
- [ ] Deploy and verify Crimson Kimono MW prices ~$3.9k instead of $11.1k
- [ ] Spot-check other glove/knife trade-ups for reasonable pricing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the pricing engine's outlier detection. Fixed price bounds have been replaced with a dynamic, confidence-aware system that intelligently adjusts price limits based on data observation levels. This enables more accurate pricing calculations and better distinguishes between legitimate high prices and statistical outliers, improving price validation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->