### PR TITLE
feat: dataviewer filter UX improvements

### DIFF
--- a/src/components/data-viewer/ScatterChart.tsx
+++ b/src/components/data-viewer/ScatterChart.tsx
@@ -11,9 +11,11 @@ interface ScatterChartProps {
   maxFloat: number;
   fullscreen?: boolean;
   visible: Record<SeriesKey, boolean>;
+  xDomainMin?: number;
+  xDomainMax?: number;
 }
 
-export function ScatterChart({ listings, saleHistory, floatBuckets, minFloat, maxFloat, fullscreen, visible }: ScatterChartProps) {
+export function ScatterChart({ listings, saleHistory, floatBuckets, minFloat, maxFloat, fullscreen, visible, xDomainMin, xDomainMax }: ScatterChartProps) {
   const W = fullscreen ? 1200 : 700;
   const H = fullscreen ? 600 : 300;
   const PAD = { top: 25, right: 25, bottom: 40, left: 70 };
@@ -52,8 +54,8 @@ export function ScatterChart({ listings, saleHistory, floatBuckets, minFloat, ma
   const maxPrice = Math.min(p95 * 1.2, allPrices[allPrices.length - 1]);
   const minPrice = 0;
 
-  const floatMin = Math.max(0, minFloat - 0.01);
-  const floatMax = Math.min(1, maxFloat + 0.01);
+  const floatMin = xDomainMin !== undefined ? xDomainMin : Math.max(0, minFloat - 0.01);
+  const floatMax = xDomainMax !== undefined ? xDomainMax : Math.min(1, maxFloat + 0.01);
 
   const x = (f: number) => PAD.left + ((f - floatMin) / (floatMax - floatMin)) * plotW;
   const y = (p: number) => PAD.top + plotH - ((Math.min(p, maxPrice) - minPrice) / (maxPrice - minPrice)) * plotH;

--- a/src/components/data-viewer/SkinDetailPanel.tsx
+++ b/src/components/data-viewer/SkinDetailPanel.tsx
@@ -56,6 +56,7 @@ export function SkinDetailPanel({ skinName, stattrak, onClose, onNavigateCollect
   const [selectedPhase, setSelectedPhase] = useState<string | null>(null);
   const [floatRange, setFloatRange] = useState<{ min: number | null; max: number | null }>({ min: null, max: null });
   const [timeRange, setTimeRange] = useState<{ from: Date | null; to: Date | null }>({ from: null, to: null });
+  const [filtersOpen, setFiltersOpen] = useState(false);
 
   useEffect(() => {
     setLoading(true);
@@ -70,6 +71,7 @@ export function SkinDetailPanel({ skinName, stattrak, onClose, onNavigateCollect
   useEffect(() => {
     setFloatRange({ min: null, max: null });
     setTimeRange({ from: null, to: null });
+    setFiltersOpen(false);
   }, [skinName]);
 
   const toggleSeries = (key: SeriesKey) => {
@@ -164,12 +166,12 @@ export function SkinDetailPanel({ skinName, stattrak, onClose, onNavigateCollect
     fs = filterByFloatRange(fs, floatRange.min, floatRange.max);
     fb = filterBucketsByFloatRange(fb, floatRange.min, floatRange.max);
 
-    // Time range filter
-    fl = filterByTimeRange(fl, "created_at", timeRange.from, timeRange.to);
-    fs = filterByTimeRange(fs, "sold_at", timeRange.from, timeRange.to);
+    // Time range filter — listings are ephemeral (no meaningful timestamp), hide when time filter active
     if (hasTimeFilter) {
+      fl = [];
       fb = [];
     }
+    fs = filterByTimeRange(fs, "sold_at", timeRange.from, timeRange.to);
 
     return { filteredListings: fl, filteredSaleHistory: fs, filteredBuckets: fb };
   }, [listings, saleHistory, bucketFloors, floatRange, timeRange, hasTimeFilter]);
@@ -259,7 +261,34 @@ export function SkinDetailPanel({ skinName, stattrak, onClose, onNavigateCollect
         maxFloat={skin.max_float}
         fullscreen={fs}
         visible={hasTimeFilter ? { ...visible, buckets: false } : visible}
+        xDomainMin={floatRange.min !== null ? floatRange.min : undefined}
+        xDomainMax={floatRange.max !== null ? floatRange.max : undefined}
       />
+      {/* Filter toggle pill + panel */}
+      <div className="mt-2">
+        <button
+          onClick={() => setFiltersOpen(o => !o)}
+          className={`text-xs px-3 py-1 rounded-full border transition-colors cursor-pointer ${
+            hasFloatFilter || hasTimeFilter
+              ? "border-blue-500/40 bg-blue-500/10 text-blue-400"
+              : "border-border text-muted-foreground hover:border-muted-foreground/50 hover:text-foreground"
+          }`}
+        >
+          Filters{hasFloatFilter || hasTimeFilter ? " \u25CF" : ""}
+        </button>
+        {filtersOpen && (
+          <div className="mt-2 p-3 border border-border rounded-md bg-card">
+            <FilterBar
+              floatRange={floatRange}
+              timeRange={timeRange}
+              onFloatRangeChange={setFloatRange}
+              onTimeRangeChange={setTimeRange}
+              skinMinFloat={skin.min_float}
+              skinMaxFloat={skin.max_float}
+            />
+          </div>
+        )}
+      </div>
     </>
   );
 
@@ -326,16 +355,6 @@ export function SkinDetailPanel({ skinName, stattrak, onClose, onNavigateCollect
           })}
         </div>
       )}
-
-      {/* Data filters */}
-      <FilterBar
-        floatRange={floatRange}
-        timeRange={timeRange}
-        onFloatRangeChange={setFloatRange}
-        onTimeRangeChange={setTimeRange}
-        skinMinFloat={skin.min_float}
-        skinMaxFloat={skin.max_float}
-      />
 
       {/* Scatter chart */}
       <div className="mb-5">


### PR DESCRIPTION
## Summary
- Float filter clamps chart x-axis domain to filter range (zoom effect) — filtered range fills chart edge-to-edge
- Filters moved below chart into toggleable pill popup (active filters shown with dot indicator); works in fullscreen mode too
- Time filter now hides all listings (ephemeral, no meaningful timestamp); only sale history shown when time filter active

## Changes
- `ScatterChart.tsx`: add `xDomainMin`/`xDomainMax` props to override skin-bounds axis domain
- `SkinDetailPanel.tsx`: filter pill toggle below chart inside `chartContent` (renders in fullscreen), time filter empties listings, pass domain props to chart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added x-axis domain customization for scatter charts.
  * Filters panel now toggles via a "Filters" pill in the chart interface.

* **Improvements**
  * Reorganized filter UI from always-visible to on-demand toggle.
  * Updated time-filter behavior to clear listings and buckets while preserving sale history filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->