### PR TITLE
fix: prevent PostgreSQL deadlocks in db-save, db-revive, and createTables

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -43,6 +43,11 @@ export function initDb(): pg.Pool {
 /** Create all tables if they don't exist. Run once at startup.
  *  Skips if tables already exist (fast path for normal restarts). */
 export async function createTables(pool: pg.Pool): Promise<void> {
+  // Serialize concurrent startup calls to prevent CREATE INDEX deadlocks when multiple
+  // processes start simultaneously. Session advisory lock is released in finally.
+  const lockClient = await pool.connect();
+  try {
+    await lockClient.query("SELECT pg_advisory_lock(1)");
   // Fast check: if trade_ups table exists, schema is already set up — skip CREATE but still run migrations
   const { rows } = await pool.query(
     "SELECT 1 FROM information_schema.tables WHERE table_name = 'trade_ups' LIMIT 1"
@@ -544,6 +549,10 @@ export async function createTables(pool: pg.Pool): Promise<void> {
         await pool.query(newDef);
       }
     }
+  }
+  } finally {
+    await lockClient.query("SELECT pg_advisory_unlock(1)");
+    lockClient.release();
   }
 }
 

--- a/server/engine/db-revive.ts
+++ b/server/engine/db-revive.ts
@@ -72,12 +72,13 @@ async function reviveStaleGeneric(
     existingSigs.add(listingSig(row.ids.split(",")));
   }
 
-  const client = await pool.connect();
-  try {
-    await client.query('BEGIN');
-
-    for (const tu of stale) {
-      checked++;
+  for (const tu of stale) {
+    checked++;
+    const client = await pool.connect();
+    let txOpen = false;
+    try {
+      await client.query('BEGIN');
+      txOpen = true;
       const { rows: inputs } = await client.query(`
         SELECT listing_id, skin_id, skin_name, collection_name, price_cents, float_value, condition, source
         FROM trade_up_inputs WHERE trade_up_id = $1
@@ -205,22 +206,22 @@ async function reviveStaleGeneric(
         ), '{}') WHERE id = $1
       `, [tu.id]);
 
-      revived++;
-      if (result.profit_cents > tu.profit_cents) improved++;
-
       // Record if newly profitable (knife revive does this, gun revive doesn't)
       if (recordCombos && result.profit_cents > 0) {
         const comboKey = [...new Set(result.inputs.map(i => i.collection_name))].sort().join("|");
         await recordProfitableCombo(client, result, comboKey);
       }
-    }
 
-    await client.query('COMMIT');
-  } catch (err) {
-    await client.query('ROLLBACK');
-    throw err;
-  } finally {
-    client.release();
+      await client.query('COMMIT');
+      txOpen = false;
+      revived++;
+      if (result.profit_cents > tu.profit_cents) improved++;
+    } catch (err) {
+      console.warn(`reviveStaleGeneric: error on trade-up ${tu.id}: ${(err as Error).message}`);
+    } finally {
+      if (txOpen) { try { await client.query('ROLLBACK'); } catch {} }
+      client.release();
+    }
   }
 
   return { checked, revived, improved };

--- a/server/engine/db-save.ts
+++ b/server/engine/db-save.ts
@@ -16,6 +16,8 @@ export async function recordProfitableCombo(pool: pg.Pool | pg.PoolClient, tu: T
     `${i.skin_name}|${i.condition}|${i.collection_name}`
   ).sort().join(";");
 
+  // Serialize concurrent upserts for the same combo_key to prevent index-level deadlocks
+  await pool.query(`SELECT pg_advisory_xact_lock(hashtext($1))`, [comboKey]);
   await pool.query(`
     INSERT INTO profitable_combos (combo_key, collections, best_profit_cents, best_roi,
       times_profitable, last_profitable_at, last_cost_cents, input_recipe)


### PR DESCRIPTION
## Summary

- **db-save.ts** (`recordProfitableCombo`): Add `pg_advisory_xact_lock(hashtext(combo_key))` before `INSERT ON CONFLICT` to serialize concurrent upserts on the same key — eliminates index-level deadlocks on `profitable_combos`
- **db-revive.ts** (`reviveStaleGeneric`): Split single large transaction (all stale trade-ups in one TX) into per-trade-up transactions — reduces lock duration from 200-330s to milliseconds, eliminating the lock chain that caused deadlocks on `trade_up_inputs`
- **db.ts** (`createTables`): Wrap with `pg_advisory_lock(1)` so concurrent API startups queue rather than race on `CREATE INDEX` statements

Fixes #12

## Test plan

- [ ] Deploy to VPS and monitor daemon restarts (baseline: 552 over prior period)
- [ ] Check API restarts drop to near-zero after deploy
- [ ] Verify profitable combos still record correctly after a discovery cycle
- [ ] Verify revive still revives stale trade-ups (check `revived` count in logs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database operation reliability by serializing concurrent table setup and initialization sequences.
  * Enhanced error handling to gracefully continue processing when individual batch operations fail instead of rolling back entire operations.

* **Performance**
  * Optimized database concurrency to prevent conflicts during simultaneous record updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->