### PR TITLE
fix: prevent CSFloat checker timeout from killing batches at 50%

### DIFF
--- a/server/csfloat-checker.ts
+++ b/server/csfloat-checker.ts
@@ -42,7 +42,7 @@ const MIN_INTERVAL_MS = 1000;  // Never faster than 1/s
 const MAX_INTERVAL_MS = 5000;  // Slowest pace when pool is low
 const DEFAULT_INTERVAL_MS = 1700; // ~35/min
 const QUEUE_SIZE = 2000;
-const QUEUE_REBUILD_INTERVAL_MS = 30 * 60 * 1000; // 30 min
+const QUEUE_REBUILD_INTERVAL_MS = 90 * 60 * 1000; // 90 min — allow full 2000-item batch to complete at ~35/min
 const VERIFY_POLL_INTERVAL_MS = 5 * 60 * 1000; // 5 min
 const CASCADE_BATCH_SIZE = 1; // Cascade immediately — no window where listing is gone but trade-up still 'active'
 
@@ -114,6 +114,7 @@ async function buildCheckQueue(pool: pg.Pool, maxSize: number): Promise<QueueLis
     JOIN skins s ON l.skin_id = s.id
     LEFT JOIN profitable_listings pl ON l.id = pl.listing_id
     WHERE l.source = 'csfloat'
+      AND (l.staleness_checked_at IS NULL OR l.staleness_checked_at < NOW() - INTERVAL '1 hour')
     ORDER BY
       CASE WHEN pl.listing_id IS NOT NULL THEN 0 ELSE 1 END,
       COALESCE(l.staleness_checked_at, '2000-01-01'::timestamptz) ASC


### PR DESCRIPTION
## Summary
- Raises `QUEUE_REBUILD_INTERVAL_MS` from 30 min → 90 min so a full 2000-item batch at ~35/min (~57 min) can complete without being hard-killed mid-way
- Adds 1h freshness filter to `buildCheckQueue` so listings checked within the last hour are excluded, preventing redundant re-checking and keeping each cycle focused on genuinely stale items

## Root Cause
At `~35/min` pace, 2000 items takes ~57 minutes. The 30-min rebuild timeout cut every batch at ~950/2000 (50%). The next cycle would rebuild with the same 950 recently-checked items at the front, causing continuous compute waste.

## Test plan
- [ ] Deploy to VPS and observe next checker cycle logs — batch should report `2000/2000` complete before rebuilding
- [ ] Queue size should drop on subsequent cycles as freshly-checked items are filtered out

Fixes #16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system efficiency by extending batch processing intervals and preventing redundant checks on recently verified listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->