### PR TITLE
fix: add statement_timeout and memory logging to Phase 5 sig load

### DIFF
--- a/server/daemon/calc-worker.ts
+++ b/server/daemon/calc-worker.ts
@@ -102,20 +102,36 @@ const rarityMap: Record<string, string> = {
       await loadDiscoveryDataFromFile(discoveryFile);
     }
 
-    // Load existing listing signatures so discovery skips combos already in DB
+    // Log memory before heavy signature load (helps diagnose OOM — see GH #22)
+    const memBefore = process.memoryUsage();
+    console.log(`  [${task}] pre-sig rss=${(memBefore.rss / 1024 / 1024).toFixed(0)}MB heap=${(memBefore.heapUsed / 1024 / 1024).toFixed(0)}MB`);
+
+    // Load existing listing signatures so discovery skips combos already in DB.
+    // Uses a dedicated client with statement_timeout to prevent runaway queries (GH #22:
+    // knife sig load took 174s vs normal 8s, likely due to DB pressure with no escape hatch).
     const tradeUpType = typeMap[task] ?? "classified_covert";
     const existingSigs = new Set<string>();
-    const { rows: sigRows } = await pool.query(`
-      SELECT trade_up_id, STRING_AGG(listing_id::text, ',' ORDER BY listing_id) as ids
-      FROM trade_up_inputs WHERE trade_up_id IN (
-        SELECT id FROM trade_ups WHERE type = $1 AND is_theoretical = false
-      ) GROUP BY trade_up_id
-    `, [tradeUpType]);
-    for (const row of sigRows) {
-      existingSigs.add(row.ids.split(",").sort().join(","));
+    const sigClient = await pool.connect();
+    try {
+      await sigClient.query("SET statement_timeout = '30000'");
+      const { rows: sigRows } = await sigClient.query(`
+        SELECT trade_up_id, STRING_AGG(listing_id::text, ',' ORDER BY listing_id) as ids
+        FROM trade_up_inputs WHERE trade_up_id IN (
+          SELECT id FROM trade_ups WHERE type = $1 AND is_theoretical = false
+        ) GROUP BY trade_up_id
+      `, [tradeUpType]);
+      for (const row of sigRows) {
+        existingSigs.add(row.ids.split(",").sort().join(","));
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`  [${task}] sig load failed (${Date.now() - workerStart}ms): ${msg} — skipping dedup`);
+    } finally {
+      sigClient.release();
     }
     const sigMs = Date.now() - workerStart;
-    console.log(`  Loaded ${existingSigs.size} existing signatures for ${task} (${sigMs}ms)`);
+    const memAfter = process.memoryUsage();
+    console.log(`  Loaded ${existingSigs.size} existing signatures for ${task} (${sigMs}ms, rss=${(memAfter.rss / 1024 / 1024).toFixed(0)}MB)`);
 
     // Phase 1: Structured discovery
     const structuredStart = Date.now();

--- a/server/daemon/index.ts
+++ b/server/daemon/index.ts
@@ -202,11 +202,12 @@ function runCalcWorker(
     child.on("error", (err) => {
       if (!settled) { settled = true; cleanup(); reject(err); }
     });
-    child.on("exit", (code) => {
+    child.on("exit", (code, signal) => {
       if (!settled) {
         settled = true;
         cleanup();
-        if (code !== 0) reject(new Error(`Worker ${task} exited with code ${code}`));
+        const reason = signal ? `signal ${signal}` : `code ${code}`;
+        if (code !== 0 || signal) reject(new Error(`Worker ${task} exited with ${reason}`));
         else reject(new Error(`Worker ${task} exited without sending results`));
       }
     });


### PR DESCRIPTION
## Summary

- Signature query in `calc-worker.ts` now uses a dedicated PG client with `SET statement_timeout = '30000'` so a runaway query fails fast (30s cap) instead of blocking for 174s+ with no escape hatch
- Memory usage (`rss` / `heapUsed`) logged before and after sig load to confirm OOM hypothesis in future incidents
- Worker exit handler in `index.ts` now captures the kill signal alongside the exit code, making OOM kills (`SIGKILL`) identifiable in logs vs. clean exits

Fixes #22

## Root cause

The knife signature query (`STRING_AGG` over `trade_up_inputs` grouped by `trade_up_id`) had no timeout. Under DB pressure, it ran for 174,655ms (vs. normal ~8,000ms). With two workers running concurrently and the main process holding price/revival caches, total RSS likely exceeded available RAM — OOM kill left no Node.js error log. The 30s `statement_timeout` forces the query to fail fast; the `catch` block logs a warning and proceeds with an empty sig set (dedup skipped, no crash).

## Test plan

- [x] All 596 existing tests pass
- [ ] Deploy to VPS and verify next Phase 5 Super-batch logs memory stats
- [ ] Confirm no silent crashes in next 2–3 hour window (previous interval between crashes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker resilience with enhanced error handling for data loading operations
  * Enhanced process termination diagnostics to differentiate between exit codes and OS signals

* **Performance**
  * Added memory usage tracking at critical workflow stages
  * Implemented connection timeout protection for data operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->