### PR TITLE
fix: prevent Phase 5 knife/restricted worker timeouts when budget <21 min

### DIFF
--- a/server/daemon/index.ts
+++ b/server/daemon/index.ts
@@ -431,8 +431,9 @@ export async function main() {
 
         const isFirstBatch = superBatchCount === 1;
         const remainingMs = engineEnd - Date.now();
+        const remainingRounds = WORKER_ROUNDS.length - roundIdx;
         const workerTimeLimit = isFirstBatch
-          ? Math.min(MAX_WORKER_TIME, Math.floor(remainingMs / WORKER_ROUNDS.length))
+          ? Math.min(MAX_WORKER_TIME, Math.floor(remainingMs / remainingRounds))
           : MIN_WORKER_TIME;
 
         const statusDetail = taskB


### PR DESCRIPTION
## Summary

- Phase 5 worker time was calculated as `remainingMs / WORKER_ROUNDS.length` (always ÷4), even for later rounds that had already consumed earlier round time
- Round 1 workers (knife + restricted) received ~210s when they need ~240s+, causing the 4-min kill timer to fire at 240322ms
- Fix: divide by `remainingRounds = WORKER_ROUNDS.length - roundIdx` so each round gets a fair share of actually-remaining time

## Test plan

- [ ] Deploy and confirm daemon logs show knife+restricted workers completing in cycles where Phase 5 budget is 19–21 min
- [ ] Confirm no regression: cycles with >21 min budget still allocate ≤300s per worker (MAX_WORKER_TIME cap unchanged)
- [ ] Check error log stays clean (no `timed out after 240322ms` entries)

Fixes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Optimization**
  * Refined worker time allocation strategy during Phase 5 processing to optimize resource distribution across processing rounds, providing larger time allocations for earlier rounds and smaller allocations for subsequent rounds within the first batch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->