### PR TITLE
fix: require MIN_STAR_KNN_OBS=10 for knife/glove KNN output pricing

### DIFF
--- a/server/engine/pricing.ts
+++ b/server/engine/pricing.ts
@@ -495,6 +495,14 @@ export function applyMonotonicityGuard(
 }
 
 /**
+ * Min KNN observations required before trusting KNN for ★ items (knives/gloves).
+ * Below this threshold, ★ skins fall back to listing floor: illiquid gloves/knives
+ * have too few sale points for KNN to avoid extrapolating above the observed max.
+ * Non-★ skins (guns) have abundant CSFloat data so no threshold is needed.
+ */
+const MIN_STAR_KNN_OBS = 10;
+
+/**
  * Look up best output price across all marketplaces.
  * Architecture: KNN-primary for all skins → condition-level fallback → float ceiling guard rail.
  * Vanilla knives (no finish): listing floor / recent sale floor.
@@ -519,7 +527,12 @@ export async function lookupOutputPrice(
   const knn = await knnOutputPriceAtFloat(pool, skinName, predictedFloat);
   let grossPrice = 0;
 
-  if (knn && knn.confidence >= 0.3) {
+  // ★ skins (knives/gloves) trade infrequently — thin KNN data (<MIN_STAR_KNN_OBS obs)
+  // can extrapolate above the observed price range. Skip KNN and use listing floor instead,
+  // which reflects real current market bids rather than sparse historical inference.
+  const knnThin = knn !== null && skinName.startsWith("★") && knn.observationCount < MIN_STAR_KNN_OBS;
+
+  if (knn && knn.confidence >= 0.3 && !knnThin) {
     grossPrice = knn.priceCents;
     // Observation-count-dependent sanity cap: low-count KNN (especially Tier 2
     // interpolation between 2 points) is unreliable for pattern-based skins where


### PR DESCRIPTION
## Summary

- ★ skins (knives/gloves) trade infrequently, so KNN builds on few sale observations
- The existing obs-count sanity cap in `lookupOutputPrice` only fires when a condition-level `refPrice` exists — but many ★ skins have no `price_data` in CSFloat, leaving the cap disabled
- Result: Hedge Maze FT was estimated at \$5,879 with 6 observations vs a \$5,657 observed max; Spearmint FT at \$3,235 with 4 observations

## Fix

Added `MIN_STAR_KNN_OBS = 10` constant in `server/engine/pricing.ts`. When a ★ skin has fewer than 10 KNN observations, KNN is skipped entirely and the fallback path uses the listing floor instead — real current market bids rather than sparse historical inference.

Non-★ skins (guns) have abundant CSFloat sale data and are unaffected.

## Test plan
- [ ] Deploy to VPS and verify top covert_knife trade-ups (ID ~756986394) reprice with listing floor for thin-data glove outputs
- [ ] Confirm trade-ups with illiquid gloves (< 10 KNN obs) show reduced / absent EVs rather than inflated ones
- [ ] Confirm ★ skins with 10+ KNN observations are still priced via KNN as before

Fixes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pricing accuracy for special items when limited historical data is available. These items now fall back to alternative pricing logic instead of relying on data sources with insufficient observations, ensuring more reliable pricing estimates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->