### PR TITLE
fix: reject input listings priced >20x per-condition reference price

### DIFF
--- a/server/engine/data-load.ts
+++ b/server/engine/data-load.ts
@@ -6,9 +6,10 @@ import pg from "pg";
 import { createWriteStream, createReadStream } from "fs";
 import { unlink } from "fs/promises";
 import { createInterface } from "readline";
-import { RARITY_ORDER } from "../../shared/types.js";
+import { RARITY_ORDER, floatToCondition } from "../../shared/types.js";
 import type { ListingWithCollection, DbSkinOutcome, AdjustedListing } from "./types.js";
 import { addAdjustedFloat } from "./selection.js";
+import { refPriceCache } from "./pricing.js";
 
 export async function getListingsForRarity(
   pool: pg.Pool,
@@ -196,6 +197,22 @@ export async function loadDiscoveryData(
   if (options?.excludeWeapons) {
     const excluded = options.excludeWeapons;
     allListings = allListings.filter(l => !(excluded as readonly string[]).includes(l.weapon));
+  }
+
+  // Outlier filter: reject input listings priced >20x the per-condition reference price.
+  // Catches sticker-premium listings (e.g. $15 on a $0.01 skin) that would inflate EV/profit.
+  // Only applies when refPriceCache is populated (i.e. buildPriceCache has run).
+  if (refPriceCache.size > 0) {
+    const before = allListings.length;
+    allListings = allListings.filter(l => {
+      const cond = floatToCondition(l.float_value);
+      const ref = refPriceCache.get(`${l.skin_name}:${cond}`);
+      return !ref || l.price_cents <= ref * 20;
+    });
+    const filtered = before - allListings.length;
+    if (filtered > 0) {
+      console.log(`  [loadDiscoveryData ${rarity}] filtered ${filtered} outlier input listings (>20x ref price)`);
+    }
   }
 
   // KNN-based input value scoring: identify underpriced listings at their specific float

--- a/server/engine/pricing.ts
+++ b/server/engine/pricing.ts
@@ -24,8 +24,9 @@ const conditionPricesCache = new Map<string, PriceAnchor[]>();
 let priceCacheBuiltAt = 0;
 const PRICE_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
-// Module-level ref price map shared between loadCsfloatRefPrices and overrideWithListingFloors/fillKnifeLastResort
-let _refPrice = new Map<string, number>();
+// Module-level ref price map shared between loadCsfloatRefPrices and overrideWithListingFloors/fillKnifeLastResort.
+// Exported so data-load.ts can filter outlier input listings before discovery.
+export let refPriceCache = new Map<string, number>();
 // Skinport median cache for listing floor sanity cap (skinName:condition → median cents)
 let _skinportMedianCache = new Map<string, number>();
 
@@ -80,14 +81,14 @@ async function overrideWithListingFloors(pool: pg.Pool): Promise<{ overrides: nu
   // Per-condition avoids filtering out legitimate FN premiums (e.g., Wild Lotus FN=$17k vs BS=$150).
   // CSFloat sales/ref first (most reliable), then Skinport median to fill gaps —
   // many skins only have CSFloat data for FN, leaving BS/WW/FT without a reference.
-  _refPrice = new Map<string, number>();
+  refPriceCache = new Map<string, number>();
   const { rows: refRows } = await pool.query(`
     SELECT skin_name, condition, MIN(CASE WHEN min_price_cents > 0 THEN min_price_cents ELSE median_price_cents END) as ref
     FROM price_data WHERE (min_price_cents > 0 OR median_price_cents > 0)
       AND source IN ('csfloat_sales', 'csfloat_ref')
     GROUP BY skin_name, condition
   `);
-  for (const r of refRows) if (r.ref > 0) _refPrice.set(`${r.skin_name}:${r.condition}`, r.ref);
+  for (const r of refRows) if (r.ref > 0) refPriceCache.set(`${r.skin_name}:${r.condition}`, r.ref);
 
   // Fill gaps with Skinport median (broader condition coverage than CSFloat)
   const { rows: spRows } = await pool.query(`
@@ -99,8 +100,8 @@ async function overrideWithListingFloors(pool: pg.Pool): Promise<{ overrides: nu
   for (const r of spRows) {
     const key = `${r.skin_name}:${r.condition}`;
     if (r.ref > 0) _skinportMedianCache.set(key, r.ref);
-    if (!_refPrice.has(key) && r.ref > 0) {
-      _refPrice.set(key, r.ref);
+    if (!refPriceCache.has(key) && r.ref > 0) {
+      refPriceCache.set(key, r.ref);
       spFills++;
     }
   }
@@ -119,7 +120,7 @@ async function overrideWithListingFloors(pool: pg.Pool): Promise<{ overrides: nu
     for (const row of rows) {
       if (row.lowest_price <= 0) continue;
       // Filter out outlier listings: >5x the per-condition reference price
-      const ref = _refPrice.get(`${row.name}:${cond.name}`);
+      const ref = refPriceCache.get(`${row.name}:${cond.name}`);
       if (ref && row.lowest_price > ref * 5) continue;
 
       const key = `${row.name}:${cond.name}`;
@@ -162,7 +163,7 @@ async function fillKnifeLastResort(pool: pg.Pool): Promise<{ lastResort: number;
 
     for (const row of rows) {
       if (row.lowest_price <= 0) continue;
-      const ref = _refPrice.get(`${row.name}:${cond.name}`);
+      const ref = refPriceCache.get(`${row.name}:${cond.name}`);
       if (ref && row.lowest_price > ref * 5) continue;
 
       const key = `${row.name}:${cond.name}`;
@@ -353,10 +354,11 @@ async function ensureFloatCeilingCache(pool: pg.Pool): Promise<void> {
   for (const row of rows) {
     // Filter outlier listings from Buff and DMarket: sticker/pattern premiums
     // can be 10-100x market price. CSFloat listings are trusted (verified buy-now).
-    // Use _refPrice (built by overrideWithListingFloors, includes Skinport fallback).
+    // Use refPriceCache (built by overrideWithListingFloors, includes Skinport fallback).
+    // Same filter applied to CSFloat input listings in data-load.ts.
     if (row.source === 'buff' || row.source === 'dmarket') {
       const condition = floatToCondition(row.float_value);
-      const ref = _refPrice.get(`${row.skin_name}:${condition}`);
+      const ref = refPriceCache.get(`${row.skin_name}:${condition}`);
       if (row.source === 'buff') {
         // Buff: filter if no ref OR >5x ref (conservative — Buff has many sticker premiums)
         if (!ref || row.price_cents > ref * 5) {
@@ -460,7 +462,7 @@ async function getListingFloor(
   const bottom3Avg = Math.round(sorted.slice(0, n).reduce((s, p) => s + p, 0) / n);
 
   // Skinport median sanity cap: catch inflated floors when outlier listings
-  // slip through (e.g. no _refPrice for BS/WW → >5x filter can't exclude them)
+  // slip through (e.g. no refPriceCache for BS/WW → >5x filter can't exclude them)
   const condition = floatToCondition(predictedFloat);
   const spMedian = _skinportMedianCache.get(`${skinName}:${condition}`);
   if (spMedian && bottom3Avg > spMedian * 3) return spMedian;


### PR DESCRIPTION
## Summary

- Sticker-premium CSFloat listings (P250 Boreal Forest BS at $15.17, Five-SeveN Forest Night WW at $10.26) were included as trade-up inputs with no outlier check, inflating EV/profit.
- Exports `refPriceCache` from `pricing.ts` (was private `_refPrice`) so `data-load.ts` can use it.
- Filters input listings where `price_cents > ref * 20` in `loadDiscoveryData`, before NDJSON serialization — workers see pre-filtered data.
- Only triggers when `refPriceCache` is populated (i.e. `buildPriceCache` has run first).

## How it works

The `refPriceCache` is already built during `buildPriceCache` from CSFloat sales/ref + Skinport medians. For a 1-cent skin, the threshold is 20 cents — comfortably below $15 sticker premiums but above the real market floor ($0.03–$0.10). Matches the existing filter pattern used for Buff/DMarket in `ensureFloatCeilingCache`.

## Test plan
- [x] 580 unit + integration tests pass
- [ ] After deploy: re-run the detection query from the issue — should return 0 rows

Fixes #26