### PR TITLE
fix: retry Phase 1 Housekeeping on transient PostgreSQL restarts (57P01)

### DIFF
--- a/server/daemon/index.ts
+++ b/server/daemon/index.ts
@@ -29,7 +29,7 @@ import {
   mergeTradeUps, updateCollectionScores, buildPriceCache, trimGlobalExcess,
   reviveStaleGunTradeUps, reviveStaleTradeUps,
   getKnifeFinishesWithPrices, CASE_KNIFE_MAP, GLOVE_GEN_SKINS,
-  cascadeTradeUpStatuses,
+  cascadeTradeUpStatuses, withRetry,
   type FinishData,
 } from "../engine.js";
 import { BudgetTracker, FreshnessTracker, TARGET_CYCLE_MS } from "./state.js";
@@ -301,8 +301,8 @@ export async function main() {
     const { clearDiscoveryCache } = await import("../engine.js");
     clearDiscoveryCache();
 
-    // Phase 1: Housekeeping
-    await phase1Housekeeping(pool, cycleCount);
+    // Phase 1: Housekeeping — withRetry handles transient DB restarts (57P01 admin_shutdown)
+    await withRetry(() => phase1Housekeeping(pool, cycleCount), 3, "Phase 1 Housekeeping");
 
     // Refresh Discord alert tops (re-validate cached tops are still active)
     try {


### PR DESCRIPTION
## Summary

- Phase 1 Housekeeping was crashing the daemon when PostgreSQL issued an `admin_shutdown` signal (error code 57P01 — e.g. during a transient PG restart or OOM recovery)
- The existing `withRetry` utility in `engine/utils.ts` already handles 57P01 with exponential backoff (1s → 2s → 4s, up to 3 retries) — it just wasn't being used for Phase 1
- Wraps the `phase1Housekeeping` call with `withRetry` so transient DB restarts are tolerated rather than crashing the daemon

## Test plan

- [ ] Push to VPS and monitor daemon logs for Phase 1 retry messages on next DB hiccup
- [ ] Verify daemon no longer crashes with 57P01 from housekeeping.ts

Fixes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of system maintenance routines to gracefully handle temporary database connectivity disruptions. Maintenance tasks now automatically retry up to three times when encountering transient issues, ensuring critical housekeeping operations complete successfully even during brief infrastructure interruptions or administrative actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->