### PR TITLE
fix: cap KNN output price at 3x Skinport median (#30)

### DIFF
--- a/server/engine/pricing.ts
+++ b/server/engine/pricing.ts
@@ -581,6 +581,15 @@ export async function lookupOutputPrice(
         grossPrice = refPrice;
       }
     }
+    // Skinport median sanity cap: KNN extrapolates from CSFloat observations which can be
+    // biased by sticker-premium sales on low-volume skins. If KNN > 3x Skinport median,
+    // cap to Skinport median — consistent with getFloatCeiling's cap and catches cases
+    // where refPrice is itself sticker-inflated (e.g. Sawed-Off Serenity BS: KNN $34.79 vs SP $2.89).
+    const spCondition = floatToCondition(predictedFloat);
+    const spMedian = skinportMedianCache.get(`${skinName}:${spCondition}`);
+    if (spMedian && grossPrice > spMedian * 3) {
+      grossPrice = spMedian;
+    }
   } else {
     // 2. Fallback: lower of condition-level ref vs listing floor at this float
     const refPrice = lookupPrice(pool, skinName, predictedFloat);


### PR DESCRIPTION
## Summary

- KNN output pricing for low-volume skins was extrapolating from sticker-inflated CSFloat observations, producing 5–17x inflated estimates vs Skinport medians
- After KNN computes a price, cap it at `3x Skinport median` if Skinport median data is available — consistent with the existing `getFloatCeiling` 3x Skinport cap
- Fixes 242 affected trade-ups (Nova | Clear Polymer BS alone: 165)

## Root cause

`lookupOutputPrice` had an observation-count-dependent cap against `refPrice` (CSFloat-derived), but `refPrice` itself can be sticker-inflated. The `_skinportMedianCache` was already populated in the same file and used in `getFloatCeiling`, but not in the KNN branch.

## Affected skins fixed

| Skin | Cond | KNN before | SP median | Ratio |
|------|------|-----------|-----------|-------|
| Nova \| Clear Polymer | BS | $39.09 | $3.77 | 10.4x |
| Sawed-Off \| Serenity | BS | $34.79 | $2.89 | 12.0x |
| Sawed-Off \| Full Stop | BS | $7.03 | $0.42 | 16.7x |
| P90 \| Glacier Mesh | FT | $272.91 | $26.05 | 10.5x |
| Dual Berettas \| Urban Shock | WW | $13.46 | $2.54 | 5.3x |

Fixes #30