### PR TITLE
fix: anchor input outlier filter to Skinport median, purge sticker-premium trade-ups

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -550,6 +550,25 @@ export async function createTables(pool: pg.Pool): Promise<void> {
       }
     }
   }
+  // Purge trade-ups with sticker-premium input listings that pre-dated the outlier filter.
+  // Removes any trade-up where an input is priced >20x the Skinport median for that skin/condition.
+  // Idempotent: no-op once bad rows are gone. Cascades to trade_up_inputs automatically.
+  const { rowCount: purgedCount } = await pool.query(`
+    DELETE FROM trade_ups tu
+    WHERE EXISTS (
+      SELECT 1 FROM trade_up_inputs ti
+      JOIN price_data pd ON pd.skin_name = ti.skin_name
+        AND pd.condition = ti.condition
+        AND pd.source = 'skinport'
+      WHERE ti.trade_up_id = tu.id
+        AND pd.median_price_cents > 0
+        AND ti.price_cents > pd.median_price_cents * 20
+    )
+  `);
+  if ((purgedCount ?? 0) > 0) {
+    console.log(`  Migration: purged ${purgedCount} sticker-premium trade-ups (input >20x Skinport median)`);
+  }
+
   } finally {
     await lockClient.query("SELECT pg_advisory_unlock(1)");
     lockClient.release();

--- a/server/engine/data-load.ts
+++ b/server/engine/data-load.ts
@@ -9,7 +9,7 @@ import { createInterface } from "readline";
 import { RARITY_ORDER, floatToCondition } from "../../shared/types.js";
 import type { ListingWithCollection, DbSkinOutcome, AdjustedListing } from "./types.js";
 import { addAdjustedFloat } from "./selection.js";
-import { refPriceCache } from "./pricing.js";
+import { refPriceCache, skinportMedianCache } from "./pricing.js";
 
 export async function getListingsForRarity(
   pool: pg.Pool,
@@ -199,19 +199,25 @@ export async function loadDiscoveryData(
     allListings = allListings.filter(l => !(excluded as readonly string[]).includes(l.weapon));
   }
 
-  // Outlier filter: reject input listings priced >20x the per-condition reference price.
+  // Outlier filter: reject input listings priced >5x the per-condition reference price.
   // Catches sticker-premium listings (e.g. $15 on a $0.01 skin) that would inflate EV/profit.
+  // Uses min(CSFloat ref, Skinport median) so sticker-inflated CSFloat sales don't raise the bar
+  // (penny skins where all CSFloat trades carry sticker premiums would otherwise escape the filter).
   // Only applies when refPriceCache is populated (i.e. buildPriceCache has run).
   if (refPriceCache.size > 0) {
     const before = allListings.length;
     allListings = allListings.filter(l => {
       const cond = floatToCondition(l.float_value);
       const ref = refPriceCache.get(`${l.skin_name}:${cond}`);
-      return !ref || l.price_cents <= ref * 20;
+      const spRef = skinportMedianCache.get(`${l.skin_name}:${cond}`);
+      // Conservative anchor: use lower of CSFloat ref and Skinport median.
+      // If only one source is available, use that.
+      const effectiveRef = ref && spRef ? Math.min(ref, spRef) : (spRef ?? ref);
+      return !effectiveRef || l.price_cents <= effectiveRef * 5;
     });
     const filtered = before - allListings.length;
     if (filtered > 0) {
-      console.log(`  [loadDiscoveryData ${rarity}] filtered ${filtered} outlier input listings (>20x ref price)`);
+      console.log(`  [loadDiscoveryData ${rarity}] filtered ${filtered} outlier input listings (>5x ref price)`);
     }
   }
 

--- a/server/engine/pricing.ts
+++ b/server/engine/pricing.ts
@@ -28,7 +28,8 @@ const PRICE_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 // Exported so data-load.ts can filter outlier input listings before discovery.
 export let refPriceCache = new Map<string, number>();
 // Skinport median cache for listing floor sanity cap (skinName:condition → median cents)
-let _skinportMedianCache = new Map<string, number>();
+// Exported so data-load.ts can use it to cap the outlier-filter reference price.
+export let skinportMedianCache = new Map<string, number>();
 
 /** Step 1: Load CSFloat ref prices (conservative condition-level averages, high volume).
  *  Sales are skewed by low-float premiums within a condition (FT 0.15 = $11 vs FT 0.32 = $6).
@@ -95,11 +96,11 @@ async function overrideWithListingFloors(pool: pg.Pool): Promise<{ overrides: nu
     SELECT skin_name, condition, median_price_cents as ref
     FROM price_data WHERE median_price_cents > 0 AND source = 'skinport'
   `);
-  _skinportMedianCache.clear();
+  skinportMedianCache.clear();
   let spFills = 0;
   for (const r of spRows) {
     const key = `${r.skin_name}:${r.condition}`;
-    if (r.ref > 0) _skinportMedianCache.set(key, r.ref);
+    if (r.ref > 0) skinportMedianCache.set(key, r.ref);
     if (!refPriceCache.has(key) && r.ref > 0) {
       refPriceCache.set(key, r.ref);
       spFills++;
@@ -243,7 +244,7 @@ export async function buildPriceCache(pool: pg.Pool, force = false) {
   priceSources.clear();
   dmarketFloorCache.clear();
   skinportFloorCache.clear();
-  _skinportMedianCache.clear();
+  skinportMedianCache.clear();
   conditionPricesCache.clear();
   _floatCeilingCache.clear();
   _floatCeilingCacheBuiltAt = 0;
@@ -464,7 +465,7 @@ async function getListingFloor(
   // Skinport median sanity cap: catch inflated floors when outlier listings
   // slip through (e.g. no refPriceCache for BS/WW → >5x filter can't exclude them)
   const condition = floatToCondition(predictedFloat);
-  const spMedian = _skinportMedianCache.get(`${skinName}:${condition}`);
+  const spMedian = skinportMedianCache.get(`${skinName}:${condition}`);
   if (spMedian && bottom3Avg > spMedian * 3) return spMedian;
 
   return bottom3Avg;


### PR DESCRIPTION
## Summary

Fixes #31 — follow-on to #28. ~350 trade-ups with sticker-premium inputs (393–1982x Skinport median) slipped through the PR #28 filter because:

- `refPriceCache` is built from CSFloat sales, which are inflated for penny skins where *all* CSFloat trades carry sticker premiums (e.g. PP-Bizon Sand Dashed FT: CSFloat median ~$30, Skinport median $0.04 — so $30 input passed the 20x filter)
- Existing bad trade-ups (discovered before PR #28) were not cleaned up

## Changes

- **`server/engine/pricing.ts`**: Export `skinportMedianCache` (renamed from `_skinportMedianCache`) so data-load can access it
- **`server/engine/data-load.ts`**: Use `min(CSFloat ref, Skinport median)` as the effective reference price; lower threshold from 20x → 5x (matches Buff/DMarket filter in pricing.ts)
- **`server/db.ts`**: Add idempotent migration that deletes trade-ups where any input is >20x Skinport median — purges the ~350 existing bad rows on next deploy

## Test plan

- [x] All 580 unit + integration tests pass
- [ ] After deploy, verify `trade_ups` count drops by ~350 and MP9 Latte Rush / Tec-9 Banana Leaf trade-ups are gone
- [ ] Monitor next discovery cycle logs for `filtered N outlier input listings (>5x ref price)` — should be near-zero going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)