### PR TITLE
fix: retroactive reprice 351K stale TU outputs + deactivate overpriced inputs

### DIFF
--- a/scripts/retroactive-reprice.ts
+++ b/scripts/retroactive-reprice.ts
@@ -1,0 +1,65 @@
+// scripts/retroactive-reprice.ts
+// One-time migration: reprice all stale trade-up outputs with current KNN cap (3x SP median),
+// and deactivate trade-ups with overpriced inputs (>5x Skinport median).
+//
+// Context: PRs #34/#35 deployed fixes but left 351K active TUs with pre-fix output prices.
+// Phase 4c reprices 20K/cycle at 30-min intervals (~8.75h for full coverage).
+// This script processes all stale TUs immediately.
+//
+// Run on VPS: npx tsx scripts/retroactive-reprice.ts
+
+import pg from "pg";
+import { buildPriceCache, repriceTradeUpOutputs } from "../server/engine.js";
+
+const { Pool } = pg;
+
+async function main() {
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+  // Step 1: Deactivate trade-ups with inputs priced >5x Skinport median.
+  // PR #35 blocks new bad inputs from entering discovery, but existing TUs
+  // (e.g. $15.37 listings on sub-$1 skins — 384x ratio) remain active on the site.
+  console.log("Step 1: Deactivating TUs with inputs >5x Skinport median...");
+  const { rowCount: deactivated } = await pool.query(`
+    UPDATE trade_ups SET listing_status = 'inactive'
+    WHERE listing_status = 'active'
+      AND is_theoretical = false
+      AND EXISTS (
+        SELECT 1 FROM trade_up_inputs ti
+        JOIN price_data pd ON pd.skin_name = ti.skin_name
+          AND pd.condition = ti.condition
+          AND pd.source = 'skinport'
+        WHERE ti.trade_up_id = trade_ups.id
+          AND pd.median_price_cents > 0
+          AND ti.price_cents > pd.median_price_cents * 5
+      )
+  `);
+  console.log(`  Deactivated ${deactivated ?? 0} TUs with overpriced inputs`);
+
+  // Step 2: Reprice all stale active trade-up outputs using current KNN + price cache.
+  // lookupOutputPrice now caps KNN at 3x Skinport median (via getListingFloor sanity cap),
+  // so repricing with current logic corrects phantom-profit outputs.
+  console.log("\nStep 2: Repricing stale trade-up outputs (batches of 20K)...");
+  await buildPriceCache(pool, true);
+
+  let totalChecked = 0;
+  let totalUpdated = 0;
+  const BATCH = 20000;
+
+  while (true) {
+    const result = await repriceTradeUpOutputs(pool, BATCH);
+    totalChecked += result.checked;
+    totalUpdated += result.updated;
+    if (result.checked > 0) {
+      console.log(`  Batch: repriced ${result.updated}/${result.checked} (running total: ${totalUpdated}/${totalChecked})`);
+    }
+    if (result.checked === 0) break;
+  }
+
+  console.log(`\nDone.`);
+  console.log(`  Bad-input TUs deactivated: ${deactivated ?? 0}`);
+  console.log(`  Output TUs repriced: ${totalUpdated}/${totalChecked}`);
+  await pool.end();
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/server/db.ts
+++ b/server/db.ts
@@ -551,8 +551,9 @@ export async function createTables(pool: pg.Pool): Promise<void> {
     }
   }
   // Purge trade-ups with sticker-premium input listings that pre-dated the outlier filter.
-  // Removes any trade-up where an input is priced >20x the Skinport median for that skin/condition.
-  // Idempotent: no-op once bad rows are gone. Cascades to trade_up_inputs automatically.
+  // Removes any trade-up where an input is priced >5x the Skinport median for that skin/condition.
+  // Threshold matches the active discovery filter (PR #35). Idempotent: no-op once clean.
+  // Cascades to trade_up_inputs automatically.
   const { rowCount: purgedCount } = await pool.query(`
     DELETE FROM trade_ups tu
     WHERE EXISTS (
@@ -562,11 +563,11 @@ export async function createTables(pool: pg.Pool): Promise<void> {
         AND pd.source = 'skinport'
       WHERE ti.trade_up_id = tu.id
         AND pd.median_price_cents > 0
-        AND ti.price_cents > pd.median_price_cents * 20
+        AND ti.price_cents > pd.median_price_cents * 5
     )
   `);
   if ((purgedCount ?? 0) > 0) {
-    console.log(`  Migration: purged ${purgedCount} sticker-premium trade-ups (input >20x Skinport median)`);
+    console.log(`  Migration: purged ${purgedCount} sticker-premium trade-ups (input >5x Skinport median)`);
   }
 
   } finally {


### PR DESCRIPTION
## Summary

- Add `scripts/retroactive-reprice.ts`: one-time migration that deactivates TUs with inputs >5x Skinport median (placeholder prices at 384x ratio), then batches `repriceTradeUpOutputs` in 20K loops until all 351K stale outputs are corrected with the new 3x SP median cap
- Update `server/db.ts` startup purge threshold from >20x to >5x Skinport median, matching the active discovery filter from PR #35

## Context

PRs #34/#35 fixed KNN cap (3x SP) and input outlier filter (5x SP), but 351K active TUs retain pre-fix output prices. Phase 4c reprices 20K/cycle at 30-min intervals — full coverage would take ~8.75h while users see phantom profits (Sawed-Off | Serenity BS at $34.79 vs $2.89 real).

## Deploy instructions

After merging to main and deploying:
```
npx tsx scripts/retroactive-reprice.ts
```

## Test plan

- [ ] Confirm deactivated count matches expected ~3,144 bad-input TUs (1,302 CSFloat + 1,842 DMarket)
- [ ] Confirm repriced count progresses through ~351K TUs with no errors
- [ ] Verify site no longer shows Sawed-Off | Serenity BS at $34.79 output

Fixes #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Executed a one-time data migration to deactivate trade-ups with excessively priced inputs relative to market values.
  * Repriced active trade-up outputs to address stale pricing data.
  * Refined pricing threshold criteria for trade-up data cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->