### PR TITLE
fix: cap estimated_price_cents at 3x Skinport median (#39)

### DIFF
--- a/server/engine/pricing.ts
+++ b/server/engine/pricing.ts
@@ -574,6 +574,13 @@ export async function lookupOutputPrice(
     grossPrice = ceiling;
   }
 
+  // 4. Hard Skinport median cap: never output more than 3x Skinport median for this condition.
+  // Catches KNN extrapolation above market reality when no nearby listings exist to form a ceiling.
+  const spMedianCap = _skinportMedianCache.get(`${skinName}:${floatToCondition(predictedFloat)}`);
+  if (spMedianCap && grossPrice > spMedianCap * 3) {
+    grossPrice = spMedianCap * 3;
+  }
+
   const netPrice = effectiveSellProceeds(grossPrice, "csfloat");
   return {
     priceCents: netPrice,


### PR DESCRIPTION
## Summary

- Adds a hard 3x Skinport median cap to `grossPrice` in `lookupOutputPrice()` (step 4) before computing net sell proceeds
- Previously, KNN extrapolation with no nearby listings could bypass `getFloatCeiling()` (which only caps the listing floor), leaving `estimated_price_cents` in `outcomes_json` inflated by up to 12x Skinport median
- Cap is applied at the single source-of-truth for output pricing, so it covers both Phase 5 discovery and Phase 4c repricing

## Test plan

- [ ] All 580 existing tests pass (verified via pre-push hook)
- [ ] Confirm affected skins (Sawed-Off Serenity BS, P90 Glacier Mesh FT, Nova Wild Six WW, MP5-SD Nitro WW) show capped `estimated_price_cents` after next reprice cycle

Fixes #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards to pricing logic to ensure item valuations remain within reasonable market benchmarks and prevent unreasonably high pricing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->