### PR TITLE
fix: cap lookupOutputPrice at 3x Skinport median for all paths (#39)

### DIFF
--- a/server/engine/pricing.ts
+++ b/server/engine/pricing.ts
@@ -613,6 +613,13 @@ export async function lookupOutputPrice(
     grossPrice = ceiling;
   }
 
+  // 4. Hard Skinport median cap: never output more than 3x Skinport median.
+  // Catches listing-floor inflation (sticker premiums) that bypasses KNN caps.
+  const spMedianCap = skinportMedianCache.get(`${skinName}:${floatToCondition(predictedFloat)}`);
+  if (spMedianCap && grossPrice > spMedianCap * 3) {
+    grossPrice = spMedianCap * 3;
+  }
+
   const netPrice = effectiveSellProceeds(grossPrice, "csfloat");
   return {
     priceCents: netPrice,


### PR DESCRIPTION
## Summary
- Adds final Skinport median cap (3x) to `lookupOutputPrice()` after all other pricing steps
- Catches listing-floor inflation (sticker premiums) that bypasses existing KNN caps
- KNN path was already capped at 2x-5x ref price, but fallback path (listing floor) had no Skinport guard
- Fixes outcomes_json.estimated_price_cents showing 3x-12x inflated values

## Impact
- Sawed-Off Serenity BS (was 12x SP), P90 Glacier Mesh FT (10.5x), Nova Wild Six WW (4.9x) will be corrected
- Existing trade-ups will get corrected as they pass through Phase 4c repricing cycles
- No effect on trade-ups already below 3x Skinport median

## Test plan
- [x] 591 tests pass
- [x] TypeScript compiles clean
- [ ] Deploy and verify top trade-ups' outcomes_json values drop to expected range

Closes #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Added pricing safeguard that limits item prices to a maximum of 3× the median market value, ensuring more consistent pricing across all items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->