### PR TITLE
fix: float ceiling uses min(cheapest, bottom5Avg) for single cheap listings

### DIFF
--- a/server/engine/pricing.ts
+++ b/server/engine/pricing.ts
@@ -453,13 +453,15 @@ async function getFloatCeiling(
   );
   if (nearbyLower.length < 5) return null;
 
-  // Sort by price ascending, take bottom-5 average as ceiling
-  // Requires 5+ listings for consensus — prevents single outlier listings from capping
+  // Sort by price ascending
   const sorted = nearbyLower.map(d => d.price).sort((a, b) => a - b);
   const n = Math.min(5, sorted.length);
   const bottom5Avg = Math.round(sorted.slice(0, n).reduce((s, p) => s + p, 0) / n);
 
-  return bottom5Avg;
+  // Also consider the cheapest single listing — if one listing at a better float
+  // is cheaper than our estimate, our worse-float output can't be worth more.
+  // Takes min(cheapest, bottom5Avg) for a conservative, correct ceiling.
+  return Math.min(sorted[0], bottom5Avg);
 }
 
 /**


### PR DESCRIPTION
## Summary
- `getFloatCeiling` previously returned only the bottom-5 average, which could be inflated when 1 cheap listing is mixed with 4 expensive ones at better floats
- Now returns `min(sorted[0], bottom5Avg)` — if any single listing at a better float is cheaper than our estimate, it caps us
- Conservative and correct: a worse-float output can't be worth more than the cheapest better-float listing

## Example (from issue)
- 1 listing at $280, 4 at $400+ (all at better float)
- Before: bottom-5 avg ≈ $375 → $369 estimate not capped
- After: min($280, $375) = $280 → estimate correctly capped

Fixes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pricing ceiling calculation to ensure it does not exceed the lowest observed price among comparable listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->