### PR TITLE
fix: KNN Tier 2 condition-boundary guard (#44)

### DIFF
--- a/server/engine/knn-pricing.ts
+++ b/server/engine/knn-pricing.ts
@@ -360,12 +360,16 @@ export async function knnOutputPriceAtFloat(
   }
 
   // === Tier 2: Linear interpolation between 2 nearest same-condition obs ===
-  if (sameCondition.length >= KNN_MIN_INTERP) {
-    const sorted = sameCondition
-      .map(o => ({ ...o, dist: Math.abs(o.float - float) }))
-      .sort((a, b) => a.dist - b.dist);
-    const a = sorted[0];
-    const b = sorted[1];
+  // Condition-boundary guard: apply KNN_MAX_FLOAT_DIST so boundary-adjacent
+  // same-condition observations (e.g. MW floats near 0.07 with FN-proximity premiums)
+  // cannot skew interpolation for targets deeper in the condition range.
+  const tier2Candidates = sameCondition
+    .map(o => ({ ...o, dist: Math.abs(o.float - float) }))
+    .filter(o => o.dist <= KNN_MAX_FLOAT_DIST)
+    .sort((a, b) => a.dist - b.dist);
+  if (tier2Candidates.length >= KNN_MIN_INTERP) {
+    const a = tier2Candidates[0];
+    const b = tier2Candidates[1];
 
     let interpolated: number;
     if (Math.abs(a.float - b.float) < 0.0001) {


### PR DESCRIPTION
## Problem

KNN Tier 2 (linear interpolation fallback) had no distance filter. It would use any two same-condition observations regardless of float distance, allowing boundary-adjacent observations — e.g. MW floats near 0.07 that carry FN-proximity premiums — to skew estimates for targets deeper in the condition range.

**Example from issue:** AWP Queen's Gambit MW at float 0.1036 → estimated \$369, actual \$297–330. The inflation came from an MW observation near float 0.07 (priced at FN-proximity premium) being used in Tier 2 interpolation with only a distant MW anchor on the other side.

## Fix

Apply `KNN_MAX_FLOAT_DIST` filter to Tier 2 candidate selection — the same distance window already enforced in Tier 1. If fewer than 2 same-condition observations exist within that window, Tier 2 returns `null` and the caller falls back to condition-level pricing (which is more reliable than a boundary-skewed interpolation).

```ts
// Before: no distance filter, any 2 same-condition obs used
const sorted = sameCondition.map(...).sort(...);

// After: hard wall at KNN_MAX_FLOAT_DIST
const tier2Candidates = sameCondition
  .map(o => ({ ...o, dist: Math.abs(o.float - float) }))
  .filter(o => o.dist <= KNN_MAX_FLOAT_DIST)  // ← boundary guard
  .sort((a, b) => a.dist - b.dist);
```

## Test plan
- [x] 580 unit + pre-push tests pass
- [x] Tier 1 behavior unchanged (already had distance filter)
- [x] Tier 2 now consistent with Tier 1 float-distance window

Fixes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved precision in pricing calculations by refining the data validation logic for interpolation operations. The system now applies stricter filtering criteria when computing pricing values, which may result in fallback behavior in edge cases with sparse data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->