### PR TITLE
fix: fallback cap when skinportMedianCache is empty

### DIFF
--- a/server/engine/pricing.ts
+++ b/server/engine/pricing.ts
@@ -537,6 +537,33 @@ export function applyMonotonicityGuard(
 const MIN_STAR_KNN_OBS = 10;
 
 /**
+ * Resolves price cap bounds for output pricing, ensuring KNN is never uncapped.
+ * Priority: Skinport median → CSFloat ref median (priceCache) → 5x cheapest obs (refPriceCache).
+ * Returns null only when no market reference exists for this skin+condition (genuinely unpriced).
+ *
+ * Fixes #49: `skinportMedianCache` silently skips when Skinport has no data for a condition,
+ * allowing KNN to extrapolate unchecked (e.g. Sawed-Off Serenity BS: $34.79 vs actual $2.89).
+ */
+export function resolveOutputCapBounds(
+  skinName: string,
+  condition: string
+): { trigger: number; knnCap: number; hardCap: number } | null {
+  const sp = skinportMedianCache.get(`${skinName}:${condition}`);
+  if (sp && sp > 0) return { trigger: sp * 3, knnCap: sp, hardCap: sp * 3 };
+
+  const cf = priceCache.get(`${skinName}:${condition}`);
+  if (cf && cf > 0) return { trigger: cf * 3, knnCap: cf, hardCap: cf * 3 };
+
+  const cheapest = refPriceCache.get(`${skinName}:${condition}`);
+  if (cheapest && cheapest > 0) {
+    const cap = cheapest * 5;
+    return { trigger: cap, knnCap: cap, hardCap: cap };
+  }
+
+  return null;
+}
+
+/**
  * Look up best output price across all marketplaces.
  * Architecture: KNN-primary for all skins → condition-level fallback → float ceiling guard rail.
  * Vanilla knives (no finish): listing floor / recent sale floor.
@@ -588,9 +615,9 @@ export async function lookupOutputPrice(
     // cap to Skinport median — consistent with getFloatCeiling's cap and catches cases
     // where refPrice is itself sticker-inflated (e.g. Sawed-Off Serenity BS: KNN $34.79 vs SP $2.89).
     const spCondition = floatToCondition(predictedFloat);
-    const spMedian = skinportMedianCache.get(`${skinName}:${spCondition}`);
-    if (spMedian && grossPrice > spMedian * 3) {
-      grossPrice = spMedian;
+    const knnCapBounds = resolveOutputCapBounds(skinName, spCondition);
+    if (knnCapBounds && grossPrice > knnCapBounds.trigger) {
+      grossPrice = knnCapBounds.knnCap;
     }
   } else {
     // 2. Fallback: lower of condition-level ref vs listing floor at this float
@@ -615,11 +642,12 @@ export async function lookupOutputPrice(
     grossPrice = ceiling;
   }
 
-  // 4. Hard Skinport median cap: never output more than 3x Skinport median for this condition.
+  // 4. Hard cap: never output more than 3x Skinport/CSFloat median (or 5x cheapest obs).
   // Catches KNN extrapolation above market reality when no nearby listings exist to form a ceiling.
-  const spMedianCap = skinportMedianCache.get(`${skinName}:${floatToCondition(predictedFloat)}`);
-  if (spMedianCap && grossPrice > spMedianCap * 3) {
-    grossPrice = spMedianCap * 3;
+  // Falls back to CSFloat ref then cheapest observation when Skinport median is absent (#49).
+  const hardCapBounds = resolveOutputCapBounds(skinName, floatToCondition(predictedFloat));
+  if (hardCapBounds && grossPrice > hardCapBounds.trigger) {
+    grossPrice = hardCapBounds.hardCap;
   }
 
   const netPrice = effectiveSellProceeds(grossPrice, "csfloat");

--- a/tests/unit/pricing.test.ts
+++ b/tests/unit/pricing.test.ts
@@ -1,6 +1,64 @@
-import { describe, it, expect } from "vitest";
-import { buildAnchors, interpolatePrice } from "../../server/engine/pricing.js";
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  buildAnchors, interpolatePrice, resolveOutputCapBounds,
+  priceCache, refPriceCache, skinportMedianCache,
+} from "../../server/engine/pricing.js";
 import type { PriceAnchor } from "../../server/engine/types.js";
+
+// ─── resolveOutputCapBounds ──────────────────────────────────────────────────
+
+describe("resolveOutputCapBounds", () => {
+  beforeEach(() => {
+    priceCache.clear();
+    refPriceCache.clear();
+    skinportMedianCache.clear();
+  });
+
+  it("returns null when no data exists for skin+condition", () => {
+    expect(resolveOutputCapBounds("Unknown Skin", "Battle-Scarred")).toBeNull();
+  });
+
+  it("uses Skinport median: trigger=3x, knnCap=1x, hardCap=3x", () => {
+    skinportMedianCache.set("Sawed-Off Serenity:Battle-Scarred", 289);
+    const result = resolveOutputCapBounds("Sawed-Off Serenity", "Battle-Scarred");
+    expect(result).toEqual({ trigger: 867, knnCap: 289, hardCap: 867 });
+  });
+
+  it("falls back to CSFloat ref when Skinport absent: same multipliers", () => {
+    priceCache.set("Skin:Battle-Scarred", 300);
+    const result = resolveOutputCapBounds("Skin", "Battle-Scarred");
+    expect(result).toEqual({ trigger: 900, knnCap: 300, hardCap: 900 });
+  });
+
+  it("falls back to 5x cheapest obs when both medians absent", () => {
+    refPriceCache.set("Skin:Battle-Scarred", 200);
+    const result = resolveOutputCapBounds("Skin", "Battle-Scarred");
+    expect(result).toEqual({ trigger: 1000, knnCap: 1000, hardCap: 1000 });
+  });
+
+  it("Skinport takes priority over CSFloat ref", () => {
+    skinportMedianCache.set("Skin:Field-Tested", 500);
+    priceCache.set("Skin:Field-Tested", 300);
+    const result = resolveOutputCapBounds("Skin", "Field-Tested");
+    expect(result?.knnCap).toBe(500);
+  });
+
+  it("CSFloat ref takes priority over cheapest obs", () => {
+    priceCache.set("Skin:Field-Tested", 300);
+    refPriceCache.set("Skin:Field-Tested", 100);
+    const result = resolveOutputCapBounds("Skin", "Field-Tested");
+    expect(result?.knnCap).toBe(300);
+  });
+
+  it("ignores zero-value cache entries", () => {
+    skinportMedianCache.set("Skin:Battle-Scarred", 0);
+    priceCache.set("Skin:Battle-Scarred", 0);
+    refPriceCache.set("Skin:Battle-Scarred", 400);
+    const result = resolveOutputCapBounds("Skin", "Battle-Scarred");
+    // Falls through to cheapest obs
+    expect(result?.trigger).toBe(2000);
+  });
+});
 
 // ─── buildAnchors ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Adds `resolveOutputCapBounds()` helper in `pricing.ts` with a priority chain: Skinport median → CSFloat ref median → 5x cheapest observation
- Replaces both bare `skinportMedianCache.get()` cap checks in `lookupOutputPrice` with the new helper — KNN now always has a ceiling when any price reference exists
- 7 new unit tests covering all fallback branches and priority ordering

## Root cause

All three cap checks used `if (spMedian && ...)` which silently short-circuits when Skinport has no data for a given skin+condition. KNN extrapolation from FN/MW/FT observations could then produce absurd BS prices (e.g. Sawed-Off Serenity BS: $34.79 vs actual ~$2.89, 72 TUs affected).

## Test plan

- [x] `resolveOutputCapBounds` unit tests: null case, Skinport path, CSFloat ref fallback, cheapest-obs fallback, priority ordering, zero-value skipping
- [x] All 587 existing tests still passing

Fixes #49

Reviewers: @twaldin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Enhanced pricing calculation robustness with improved fallback mechanisms for market reference data. Pricing lookups now gracefully handle missing primary data sources, ensuring more consistent and reliable price calculations across all market conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->