### PR TITLE
fix: add deadline check in inner j-loop of two-collection scan

### DIFF
--- a/server/engine/discovery.ts
+++ b/server/engine/discovery.ts
@@ -278,6 +278,7 @@ export async function findProfitableTradeUps(
     for (let i = 0; i < colIds.length; i++) {
       if (pastDeadline()) break;
       for (let j = i + 1; j < colIds.length; j++) {
+        if (pastDeadline()) break;
         pairsProcessed++;
         const colA = colIds[i];
         const colB = colIds[j];

--- a/server/engine/knife-discovery.ts
+++ b/server/engine/knife-discovery.ts
@@ -215,6 +215,7 @@ export async function findProfitableKnifeTradeUps(
   for (let i = 0; i < knifeCollections.length; i++) {
     if (pastDeadline()) break;
     for (let j = i + 1; j < knifeCollections.length; j++) {
+      if (pastDeadline()) break;
       const colA = knifeCollections[i];
       const colB = knifeCollections[j];
       const listingsA = byCollection.get(colA)!;


### PR DESCRIPTION
## Summary
- `findProfitableKnifeTradeUps` and `findProfitableTradeUps` both checked `pastDeadline()` only in the **outer** `i` loop of the two-collection combos section
- The inner `j` loop (one collection pair) can contain hundreds of `await` calls (9 splits × ~50 float targets × condition combos per pair), causing workers to blow past their deadline by the full cost of one pair
- With covert_knife at 116K+ total entries, per-pair cost has grown enough to cause consistent 240s+ timeouts for knife and restricted workers

## Root cause
```js
for (let i = 0; i < knifeCollections.length; i++) {
  if (pastDeadline()) break;  // ✅ checked here
  for (let j = i + 1; j < knifeCollections.length; j++) {
    // ❌ no check — one pair is hundreds of awaits
    for (const countA of [1, 2, 3, 4]) {
      for (const target of knifeTransitionPoints) { ... }
    }
  }
}
```

## Fix
Added `if (pastDeadline()) break;` at the top of the inner `j` loop in both `server/engine/knife-discovery.ts` and `server/engine/discovery.ts`.

## Test plan
- [x] All 580 existing tests pass
- [x] Workers should now stop the two-collection scan promptly when the deadline is hit, rather than completing the full current `i`-row of pairs

Fixes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deadline handling in discovery operations to ensure work stops promptly when time limits are reached, rather than continuing until outer loop boundaries complete. This enhances system responsiveness and prevents extended processing beyond intended timeframes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->