### PR TITLE
feat: exponential time-decay for KNN age weighting (30-day half-life)

### DIFF
--- a/server/engine/knn-pricing.ts
+++ b/server/engine/knn-pricing.ts
@@ -167,15 +167,12 @@ const KNN_FRESHNESS_MIN = 2; // require at least 2 observations from last 14 day
 export const KNN_MAX_OBS_AGE_DAYS = 180;
 
 /**
- * Dynamic half-life based on observation density:
- * - < 10 observations in 45 days → 30 days (rare skins need longer memory)
- * - > 50 observations → 10 days (liquid skins can use fresh data)
- * - Linear interpolation between
+ * Exponential time-decay weight for a KNN observation.
+ * Uses a fixed 30-day half-life: weight = 2^(-ageDays/30).
+ * Fresh obs (0d) → 1.0, 30d → 0.5, 185d → ~0.014.
  */
-function dynamicHalfLife(observationCount: number): number {
-  if (observationCount <= 10) return 30;
-  if (observationCount >= 50) return 10;
-  return Math.round(30 - (observationCount - 10) * (30 - 10) / (50 - 10));
+export function knnTimeDecay(ageDays: number): number {
+  return Math.pow(2, -ageDays / 30);
 }
 
 async function ensureKnnCache(pool: pg.Pool) {
@@ -206,16 +203,15 @@ async function ensureKnnCache(pool: pg.Pool) {
     arr.push(row);
   }
 
-  // Build cache with per-skin dynamic half-life + track freshness + CSFloat sale presence
+  // Build cache with exponential time-decay + track freshness + CSFloat sale presence
   for (const [skinName, skinRows] of rawBySkin) {
-    const halfLife = dynamicHalfLife(skinRows.length);
     const arr: { float: number; price: number; weight: number; condition: string }[] = [];
     let recentCount = 0;
     let hasCsfloat = false;
     let hasBuff = false;
     for (const row of skinRows) {
       const baseWeight = KNN_SOURCE_WEIGHTS[row.source] ?? 1.0;
-      const ageDecay = 1 / (1 + (row.age_days || 0) / halfLife);
+      const ageDecay = knnTimeDecay(row.age_days || 0);
       arr.push({
         float: row.float_value,
         price: row.price_cents,

--- a/tests/unit/knn-pricing.test.ts
+++ b/tests/unit/knn-pricing.test.ts
@@ -1,5 +1,34 @@
 import { describe, it, expect } from "vitest";
-import { getFloatBucket, FLOAT_BUCKETS } from "../../server/engine/knn-pricing.js";
+import { getFloatBucket, FLOAT_BUCKETS, knnTimeDecay } from "../../server/engine/knn-pricing.js";
+
+// ─── knnTimeDecay ────────────────────────────────────────────────────────────
+
+describe("knnTimeDecay", () => {
+  it("fresh observation (0 days) has weight 1.0", () => {
+    expect(knnTimeDecay(0)).toBe(1.0);
+  });
+
+  it("30-day-old observation has weight 0.5 (one half-life)", () => {
+    expect(knnTimeDecay(30)).toBeCloseTo(0.5, 5);
+  });
+
+  it("60-day-old observation has weight 0.25 (two half-lives)", () => {
+    expect(knnTimeDecay(60)).toBeCloseTo(0.25, 5);
+  });
+
+  it("185-day stale outlier has weight < 0.02 (neutralized)", () => {
+    // Nova Ocular Sep 2025 obs (float 0.326, 500 cents) poisoned KNN for a
+    // normally 84–140 cent skin. At 185 days: 2^(-185/30) ≈ 0.014.
+    expect(knnTimeDecay(185)).toBeLessThan(0.02);
+    expect(knnTimeDecay(185)).toBeGreaterThan(0);
+  });
+
+  it("monotonically decreasing with age", () => {
+    expect(knnTimeDecay(10)).toBeGreaterThan(knnTimeDecay(30));
+    expect(knnTimeDecay(30)).toBeGreaterThan(knnTimeDecay(90));
+    expect(knnTimeDecay(90)).toBeGreaterThan(knnTimeDecay(185));
+  });
+});
 
 // ─── getFloatBucket ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Replaces harmonic age decay `1/(1 + age/halfLife)` (with dynamic half-life) with a pure exponential `2^(-ageDays/30)` — a fixed 30-day half-life
- Extracts `knnTimeDecay(ageDays)` as an exported pure function; removes the now-unused `dynamicHalfLife` helper
- Adds 5 TDD unit tests covering fresh obs (1.0), half-life (0.5 @ 30d), two half-lives (0.25 @ 60d), stale outlier neutralized (< 0.02 @ 185d), and monotonic decay

## Why
A Sep 2025 observation (185d old, float 0.326, 500 cents) was poisoning the Nova Ocular KNN curve — causing a 368-cent estimate for a skin that normally sells for 84–140 cents. With the exponential formula its weight is ~0.014, effectively neutralized. 84% of 407K observations are <30 days old so typical skins are unaffected.

## Test Plan
- [ ] `knnTimeDecay(0) === 1.0`
- [ ] `knnTimeDecay(30) ≈ 0.5`
- [ ] `knnTimeDecay(185) < 0.02`
- [ ] 585 tests passing

Closes #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined the pricing calculation algorithm to use predictable exponential time-decay weighting. Older observations now consistently decay based on age rather than observation density per category.

* **Tests**
  * Added test coverage for the updated time-decay function, including boundary and monotonic behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->