### PR TITLE
fix: wire resolveOutputCapBounds into listing floor fallback path (#61)

### DIFF
--- a/scripts/reprice-listing-floor-stale.ts
+++ b/scripts/reprice-listing-floor-stale.ts
@@ -1,0 +1,34 @@
+// scripts/reprice-listing-floor-stale.ts
+// One-time migration: null out output_repriced_at on active TUs priced before the
+// listing-floor cap-bounds fix (GH #61) so the daemon reprices them on next cycle.
+//
+// Context: resolveOutputCapBounds() was dead code — listing floor fallback path ran
+// uncapped when KNN was null and spMedian was absent. Stale collector-premium listings
+// (e.g. Sawed-Off | Serenity BS at 3479¢ vs actual ~289¢) flowed through unguarded.
+// Setting output_repriced_at = NULL enqueues all 349K affected TUs for Phase 4c repricing.
+//
+// Run on VPS: npx tsx scripts/reprice-listing-floor-stale.ts
+
+import pg from "pg";
+
+const { Pool } = pg;
+
+const CUTOFF = "2026-03-28T18:39:00Z";
+
+async function main() {
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+  console.log(`Nulling output_repriced_at for active TUs repriced before ${CUTOFF}...`);
+
+  const { rowCount } = await pool.query(`
+    UPDATE trade_ups
+    SET output_repriced_at = NULL
+    WHERE listing_status = 'active'
+      AND output_repriced_at < $1
+  `, [CUTOFF]);
+
+  console.log(`Done. ${rowCount ?? 0} trade-ups enqueued for repricing.`);
+  await pool.end();
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/server/engine/pricing.ts
+++ b/server/engine/pricing.ts
@@ -637,8 +637,14 @@ export function resolvePriceWithFallbacks(params: FallbackParams): FallbackResul
       grossPrice = Math.min(refPrice, listingFloor);
       source = "min(ref, floor)";
     } else if (listingFloor != null && listingFloor > 0) {
-      grossPrice = listingFloor;
-      source = "listing floor";
+      const capBounds = resolveOutputCapBounds(skinName, floatToCondition(predictedFloat));
+      if (capBounds && listingFloor > capBounds.knnCap) {
+        grossPrice = capBounds.knnCap;
+        source = "cap-bounded (listing floor)";
+      } else {
+        grossPrice = listingFloor;
+        source = "listing floor";
+      }
     } else if (refPrice > 0) {
       grossPrice = refPrice;
       source = "ref";

--- a/tests/unit/pricing-resolver.test.ts
+++ b/tests/unit/pricing-resolver.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { resolvePriceWithFallbacks, priceCache } from "../../server/engine/pricing.js";
+import { resolvePriceWithFallbacks, priceCache, skinportMedianCache, refPriceCache } from "../../server/engine/pricing.js";
 import type { FallbackParams, KnnEstimate } from "../../server/engine/types.js";
 
 function knn(overrides: Partial<KnnEstimate> = {}): KnnEstimate {
@@ -19,7 +19,7 @@ function p(overrides: Partial<FallbackParams> = {}): FallbackParams {
   };
 }
 
-beforeEach(() => { priceCache.clear(); });
+beforeEach(() => { priceCache.clear(); skinportMedianCache.clear(); refPriceCache.clear(); });
 
 // ── KNN path ───────────────────────────────────────────────────────────────
 
@@ -234,5 +234,65 @@ describe("sparse-condition cap (GH #54)", () => {
     }));
     // refPrice>0 → uses obs-count cap (2×refPrice=500), not sparse cap
     expect(r.grossPrice).toBe(250); // 600 > 2×250=500 → ref-capped
+  });
+});
+
+// ── Listing floor cap bounds (GH #61) ────────────────────────────────────────
+
+describe("listing floor cap bounds (GH #61)", () => {
+  it("caps inflated listing floor to skinportMedianCache knnCap when KNN null and refPrice 0", () => {
+    // Sawed-Off | Serenity BS: stale listing at 3479¢, but spMedian=289¢
+    // Bug: listing floor was used uncapped → 3479¢. Fix: cap to spMedian (289¢).
+    skinportMedianCache.set("Sawed-Off | Serenity:Battle-Scarred", 289);
+    const r = resolvePriceWithFallbacks(p({
+      knn: null,
+      refPrice: 0,
+      listingFloor: 3479,
+      skinName: "Sawed-Off | Serenity",
+      predictedFloat: 0.55, // Battle-Scarred
+    }));
+    expect(r.grossPrice).toBe(289);
+    expect(r.source).toBe("cap-bounded (listing floor)");
+  });
+
+  it("caps inflated listing floor to refPriceCache (5x cheapest) when spMedian also missing", () => {
+    // No spMedian, but refPriceCache has cheapest obs → cap = 5× cheapest
+    refPriceCache.set("Sawed-Off | Serenity:Battle-Scarred", 100);
+    const r = resolvePriceWithFallbacks(p({
+      knn: null,
+      refPrice: 0,
+      listingFloor: 3479,
+      skinName: "Sawed-Off | Serenity",
+      predictedFloat: 0.55,
+    }));
+    expect(r.grossPrice).toBe(500); // 5× cheapest = 5×100
+    expect(r.source).toBe("cap-bounded (listing floor)");
+  });
+
+  it("does not cap listing floor when it is within the knnCap", () => {
+    // Listing floor is already below spMedian → use it as-is
+    skinportMedianCache.set("AK-47 | Redline:Field-Tested", 500);
+    const r = resolvePriceWithFallbacks(p({
+      knn: null,
+      refPrice: 0,
+      listingFloor: 400,
+      skinName: "AK-47 | Redline",
+      predictedFloat: 0.25, // Field-Tested
+    }));
+    expect(r.grossPrice).toBe(400);
+    expect(r.source).toBe("listing floor");
+  });
+
+  it("does not cap listing floor when resolveOutputCapBounds returns null (no market reference)", () => {
+    // skinportMedianCache, priceCache, refPriceCache all empty → no cap available
+    const r = resolvePriceWithFallbacks(p({
+      knn: null,
+      refPrice: 0,
+      listingFloor: 3479,
+      skinName: "Some Rare Skin | With No Data",
+      predictedFloat: 0.55,
+    }));
+    expect(r.grossPrice).toBe(3479);
+    expect(r.source).toBe("listing floor");
   });
 });


### PR DESCRIPTION
## Summary
- `resolveOutputCapBounds()` was dead code — never called despite having the right SP median → CSFloat ref → 5× cheapest fallback chain
- Wired it into the `listingFloor`-only branch of `resolvePriceWithFallbacks`: inflated floors now get capped to `knnCap` before use
- Adds `scripts/reprice-listing-floor-stale.ts` to null `output_repriced_at` on ~349K active TUs so the daemon reprices them on next cycle

## Test Plan
- [x] TDD: 4 new tests in `pricing-resolver.test.ts` — RED confirmed (3479¢ returned uncapped), GREEN after fix
- [x] Full suite: 644 tests passing
- [ ] Run migration on VPS: `npx tsx scripts/reprice-listing-floor-stale.ts`

Closes #61

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed pricing calculation to apply market-based caps to listing floor prices when market data is available, preventing prices from exceeding reference bounds and staying aligned with market conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->