### PR TITLE
fix: Phase 4c prioritizes stale profitable TU outputs (#64)

### DIFF
--- a/server/engine/db-stats.ts
+++ b/server/engine/db-stats.ts
@@ -188,7 +188,9 @@ export async function repriceTradeUpOutputs(
     WHERE is_theoretical = false AND listing_status = 'active'
       AND outcomes_json IS NOT NULL
       AND (output_repriced_at IS NULL OR output_repriced_at < NOW() - INTERVAL '2 hours')
-    ORDER BY output_repriced_at ASC NULLS FIRST, roi_percentage DESC
+    ORDER BY
+      CASE WHEN profit_cents > 500 THEN 0 ELSE 1 END,
+      output_repriced_at ASC NULLS FIRST
     LIMIT $1
   `, [limit]);
 

--- a/tests/integration/reprice-priority.test.ts
+++ b/tests/integration/reprice-priority.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import pg from "pg";
+import { createTestApp, type TestContext } from "./setup.js";
+import { repriceTradeUpOutputs } from "../../server/engine/db-stats.js";
+
+/**
+ * Inserts a minimal trade_up row and returns its id.
+ * outcomes_json='[]' so repriceTradeUpOutputs immediately stamps output_repriced_at
+ * without needing any real price data.
+ */
+async function insertTU(
+  pool: pg.Pool,
+  opts: {
+    profitCents: number;
+    outputRepricedAt: string | null;
+  }
+): Promise<number> {
+  const { rows } = await pool.query(
+    `INSERT INTO trade_ups
+       (total_cost_cents, expected_value_cents, profit_cents, roi_percentage,
+        listing_status, is_theoretical, outcomes_json, output_repriced_at)
+     VALUES ($1, $2, $3, $4, 'active', false, '[]', $5)
+     RETURNING id`,
+    [
+      10000,
+      10000 + opts.profitCents,
+      opts.profitCents,
+      Math.round((opts.profitCents / 10000) * 10000) / 100,
+      opts.outputRepricedAt,
+    ]
+  );
+  return rows[0].id as number;
+}
+
+describe("repriceTradeUpOutputs — Phase 4c selection priority", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    ctx = await createTestApp({ defaultTier: "pro" });
+  });
+
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  it("processes a profitable TU before an unprofitable TU when both are stale", async () => {
+    // Both have output_repriced_at = NULL (never repriced), but only limit=1 will be processed.
+    const unprofitableId = await insertTU(ctx.pool, { profitCents: -500, outputRepricedAt: null });
+    const profitableId = await insertTU(ctx.pool, { profitCents: 1000, outputRepricedAt: null });
+
+    const result = await repriceTradeUpOutputs(ctx.pool, 1);
+
+    expect(result.checked).toBe(1);
+
+    // The profitable TU should have been processed (output_repriced_at set)
+    const { rows: profitable } = await ctx.pool.query(
+      "SELECT output_repriced_at FROM trade_ups WHERE id = $1", [profitableId]
+    );
+    const { rows: unprofitable } = await ctx.pool.query(
+      "SELECT output_repriced_at FROM trade_ups WHERE id = $1", [unprofitableId]
+    );
+
+    expect(profitable[0].output_repriced_at).not.toBeNull();
+    expect(unprofitable[0].output_repriced_at).toBeNull();
+  });
+
+  it("processes the oldest profitable TU first when multiple profitable TUs are stale", async () => {
+    // newerProfitableId repriced 3 hours ago; olderProfitableId repriced 5 hours ago
+    const olderProfitableId = await insertTU(ctx.pool, {
+      profitCents: 2000,
+      outputRepricedAt: new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString(),
+    });
+    const newerProfitableId = await insertTU(ctx.pool, {
+      profitCents: 800,
+      outputRepricedAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+    });
+
+    const result = await repriceTradeUpOutputs(ctx.pool, 1);
+
+    expect(result.checked).toBe(1);
+
+    const { rows: older } = await ctx.pool.query(
+      "SELECT output_repriced_at FROM trade_ups WHERE id = $1",
+      [olderProfitableId]
+    );
+    const { rows: newer } = await ctx.pool.query(
+      "SELECT output_repriced_at FROM trade_ups WHERE id = $1",
+      [newerProfitableId]
+    );
+
+    // Older profitable TU should have been touched (updated to a recent timestamp)
+    expect(new Date(older[0].output_repriced_at).getTime()).toBeGreaterThan(
+      Date.now() - 10_000
+    );
+    // Newer profitable TU should still have the old timestamp (not yet repriced)
+    expect(new Date(newer[0].output_repriced_at).getTime()).toBeLessThan(
+      Date.now() - 2 * 60 * 60 * 1000
+    );
+  });
+
+  it("skips TUs that were repriced within the 2-hour window", async () => {
+    // Repriced 30 minutes ago — should not qualify
+    const freshId = await insertTU(ctx.pool, {
+      profitCents: 5000,
+      outputRepricedAt: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+    });
+    // Stale profitable TU — should qualify
+    const staleId = await insertTU(ctx.pool, {
+      profitCents: 1000,
+      outputRepricedAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+    });
+
+    await repriceTradeUpOutputs(ctx.pool, 10);
+
+    const { rows: fresh } = await ctx.pool.query(
+      "SELECT output_repriced_at FROM trade_ups WHERE id = $1",
+      [freshId]
+    );
+    const { rows: stale } = await ctx.pool.query(
+      "SELECT output_repriced_at FROM trade_ups WHERE id = $1",
+      [staleId]
+    );
+
+    // Fresh TU timestamp should be unchanged (still 30 min ago)
+    expect(new Date(fresh[0].output_repriced_at).getTime()).toBeLessThan(
+      Date.now() - 25 * 60 * 1000
+    );
+    // Stale TU should have been repriced now
+    expect(new Date(stale[0].output_repriced_at).getTime()).toBeGreaterThan(
+      Date.now() - 10_000
+    );
+  });
+});

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -114,6 +114,7 @@ async function createSchema(bootstrapPool: pg.Pool) {
       profit_streak INTEGER NOT NULL DEFAULT 0,
       previous_inputs TEXT,
       outcomes_json TEXT,
+      output_repriced_at TIMESTAMPTZ,
       created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
       ,input_sources TEXT[] NOT NULL DEFAULT '{}'
     );


### PR DESCRIPTION
## Summary

- Changes ORDER BY in `repriceTradeUpOutputs` to sort profitable TUs (`profit_cents > 500`) before unprofitable ones, then by `output_repriced_at ASC NULLS FIRST` within each tier
- Adds `output_repriced_at` column to integration test schema
- Adds 3 integration tests covering: profitable-first selection, oldest-profitable-first, and 2h freshness window

## Root cause

Phase 4c was ordering purely by `output_repriced_at ASC NULLS FIRST, roi_percentage DESC`. With 636K active TUs and a 6,500/cycle batch, stale profitable TUs were processed in insertion order alongside all other TUs — clearing only ~53/1,359 per cycle.

## Fix

```sql
ORDER BY
  CASE WHEN profit_cents > 500 THEN 0 ELSE 1 END,
  output_repriced_at ASC NULLS FIRST
```

The ~2,380 profitable TUs now fit within a single 20K batch, ensuring they're always repriced each cycle before touching unprofitable TUs.

Closes #64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Trade-up repricing algorithm now prioritizes items by profitability, ensuring higher-profit trades receive priority processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->