### PR TITLE
perf: batch cascade UPDATEs + index-friendly preserved-TU purge (#72)

### DIFF
--- a/server/engine/db-status.ts
+++ b/server/engine/db-status.ts
@@ -182,10 +182,11 @@ export async function refreshListingStatuses(pool: pg.Pool): Promise<{ active: n
  * Purge preserved trade-ups older than maxDays.
  */
 export async function purgeExpiredPreserved(pool: pg.Pool, maxDays = 2): Promise<number> {
-  // Use listing_status equality + preserved_at range to leverage composite index
+  // Use listing_status IN + preserved_at range to leverage composite index
   // idx_trade_ups_listing_status(listing_status, preserved_at) instead of EXTRACT() function scan.
-  // Preserved TUs are always listing_status='partial' (stale TUs are deleted immediately in cascade).
-  const condition = "listing_status = 'partial' AND preserved_at < NOW() - ($1 * INTERVAL '1 day')";
+  // Both 'partial' (cascadeTradeUpStatuses) and 'stale' (refreshListingStatuses, claims) can have
+  // preserved_at set and must be purged together.
+  const condition = "listing_status IN ('partial', 'stale') AND preserved_at < NOW() - ($1 * INTERVAL '1 day')";
 
   // Delete inputs first (trade_up_inputs.trade_up_id FK has ON DELETE CASCADE but explicit
   // batch delete is faster than row-by-row trigger for large counts), then trade-ups.

--- a/server/engine/db-status.ts
+++ b/server/engine/db-status.ts
@@ -66,26 +66,42 @@ export async function cascadeTradeUpStatuses(pool: pg.Pool, listingIds: string[]
       totalUpdated += toDelete.length;
     }
 
-    // Update partial/active trade-ups
+    // Update partial/active trade-ups — batched by new status to avoid per-row round-trips
     if (toUpdate.length > 0) {
-      for (const row of toUpdate) {
-        const newStatus = row.missing === 0 ? 'active' : 'partial';
-        const result = await pool.query(`
+      const partialIds = toUpdate.filter(r => r.missing > 0).map(r => r.trade_up_id);
+      const activeIds = toUpdate.filter(r => r.missing === 0).map(r => r.trade_up_id);
+
+      if (partialIds.length > 0) {
+        const r = await pool.query(`
           UPDATE trade_ups SET
-            listing_status = $1,
+            listing_status = 'partial',
             preserved_at = CASE
-              WHEN $2 > 0 AND listing_status = 'active' THEN NOW()
-              WHEN $2 = 0 THEN NULL
+              WHEN listing_status = 'active' THEN NOW()
               ELSE preserved_at
             END
-          WHERE id = $3
-            AND listing_status IS DISTINCT FROM $1
+          WHERE id = ANY($1)
+            AND listing_status IS DISTINCT FROM 'partial'
             AND NOT EXISTS (
               SELECT 1 FROM trade_up_claims tc
-              WHERE tc.trade_up_id = $3 AND tc.released_at IS NULL AND tc.expires_at > NOW()
+              WHERE tc.trade_up_id = trade_ups.id AND tc.released_at IS NULL AND tc.expires_at > NOW()
             )
-        `, [newStatus, row.missing, row.trade_up_id]);
-        totalUpdated += result.rowCount ?? 0;
+        `, [partialIds]);
+        totalUpdated += r.rowCount ?? 0;
+      }
+
+      if (activeIds.length > 0) {
+        const r = await pool.query(`
+          UPDATE trade_ups SET
+            listing_status = 'active',
+            preserved_at = NULL
+          WHERE id = ANY($1)
+            AND listing_status IS DISTINCT FROM 'active'
+            AND NOT EXISTS (
+              SELECT 1 FROM trade_up_claims tc
+              WHERE tc.trade_up_id = trade_ups.id AND tc.released_at IS NULL AND tc.expires_at > NOW()
+            )
+        `, [activeIds]);
+        totalUpdated += r.rowCount ?? 0;
       }
     }
   }
@@ -166,9 +182,13 @@ export async function refreshListingStatuses(pool: pg.Pool): Promise<{ active: n
  * Purge preserved trade-ups older than maxDays.
  */
 export async function purgeExpiredPreserved(pool: pg.Pool, maxDays = 2): Promise<number> {
-  const condition = "preserved_at IS NOT NULL AND EXTRACT(EPOCH FROM NOW() - preserved_at::timestamptz) / 86400.0 > $1";
+  // Use listing_status equality + preserved_at range to leverage composite index
+  // idx_trade_ups_listing_status(listing_status, preserved_at) instead of EXTRACT() function scan.
+  // Preserved TUs are always listing_status='partial' (stale TUs are deleted immediately in cascade).
+  const condition = "listing_status = 'partial' AND preserved_at < NOW() - ($1 * INTERVAL '1 day')";
 
-  // Delete inputs first (no FK cascade), then trade-ups — use subquery to avoid 500K+ placeholder lists
+  // Delete inputs first (trade_up_inputs.trade_up_id FK has ON DELETE CASCADE but explicit
+  // batch delete is faster than row-by-row trigger for large counts), then trade-ups.
   await pool.query(`DELETE FROM trade_up_inputs WHERE trade_up_id IN (SELECT id FROM trade_ups WHERE ${condition})`, [maxDays]);
   const { rowCount } = await pool.query(`DELETE FROM trade_ups WHERE ${condition}`, [maxDays]);
   return rowCount ?? 0;


### PR DESCRIPTION
## Summary

- **cascadeTradeUpStatuses**: replaced per-row UPDATE loop with two bulk UPDATEs (`id = ANY($1)`), one for TUs going partial and one going active. For 2,545 Buff listings deleted this eliminates potentially 10K+ DB round-trips.
- **purgeExpiredPreserved**: rewrote `EXTRACT(EPOCH …) > $1` condition to `listing_status = 'partial' AND preserved_at < NOW() - ($1 * INTERVAL '1 day')`, allowing the existing composite index `idx_trade_ups_listing_status(listing_status, preserved_at)` to drive the query instead of a full table scan.

## Why this fixes #72

Phase 1 C4 took 19.6 min (vs 2–5 min normal):
- 13 min attributed to Buff cascade deletes — caused by O(N) round-trips in `cascadeTradeUpStatuses.toUpdate` loop
- 5 min for 23K preserved-TU purge — caused by function-based EXTRACT condition bypassing the composite index

## Test plan

- [x] 502 unit tests pass (unchanged)
- [ ] Verify Phase 1 duration drops to normal range on next daemon cycle

Fixes #72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented listing status changes for items with active claims, avoiding improper state transitions.

* **Performance Improvements**
  * Consolidated status updates into batched operations for faster processing.
  * Improved cleanup of expired preserved listings using a direct time-range condition for more efficient deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->