### PR TITLE
fix(seo): emit blog canonical/sitemap URLs with trailing slash (#95)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -974,7 +974,10 @@ app.use((req, res, next) => {
       if (!post) return next();
       const ua = req.headers["user-agent"] || "";
       const title = `${post.title} | TradeUpBot Blog`;
-      const url = `https://tradeupbot.app/blog/${req.params.slug}`;
+      // Trailing slash matches the URL the server actually serves content
+      // at; without it the canonical points at the redirected (non-trailing)
+      // form and Google sees a redirect loop on the canonical chain (#95).
+      const url = `https://tradeupbot.app/blog/${req.params.slug}/`;
       res.setHeader("Content-Type", "text/html");
       if (isCrawler(ua)) {
         res.send(buildSeoHtml({

--- a/server/routes/sitemap.ts
+++ b/server/routes/sitemap.ts
@@ -43,7 +43,9 @@ export function buildStaticSitemap(base: string, lastmod: string): string {
   ];
 
   for (const slug of BLOG_SLUGS) {
-    staticPages.push({ path: `/blog/${slug}`, priority: "0.7", freq: "monthly" });
+    // Match the trailing-slash form the server actually serves so the
+    // sitemap, canonical, and 301-target URL all agree (#95).
+    staticPages.push({ path: `/blog/${slug}/`, priority: "0.7", freq: "monthly" });
   }
 
   const urls = staticPages.map(p =>


### PR DESCRIPTION
Fixes #95. The server serves blog post HTML at `/blog/<slug>/` (with trailing slash) and 301-redirects the non-trailing-slash variant. But:

- The `<link rel="canonical">` emitted for crawlers in `server/index.ts:977` pointed at the non-trailing-slash URL.
- The sitemap (`server/routes/sitemap.ts:46`) listed the blog posts under their non-trailing-slash paths.

Combined, this produced a redirect-chain canonical: Google fetches the canonical URL, gets a 301 to the trailing-slash version, whose canonical points back to the non-trailing-slash version. GSC indexed both variants separately and split signals across them.

## Change

- `server/index.ts:977` — append `/` to the canonical URL.
- `server/routes/sitemap.ts:46` — append `/` to the path pushed for each `BLOG_SLUGS` entry.

Both now match the actual content URL the server serves at, breaking the redirect loop on the canonical chain.

## Test plan

- [x] `npx tsc --noEmit` — no errors in the changed files
- [x] No code-path change beyond the URL string; both call sites already used template-literal interpolation so the fix is purely additive
- [x] Other entries in the sitemap (the `staticPages` literal) already use no trailing slash because those pages are served without one — unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Standardized blog post URLs to consistently use trailing-slash format across SEO metadata and sitemap entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->