### PR TITLE
Fix issue bundle #84-#104 from audit-tradeupbot

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -813,13 +813,21 @@ app.use((req, res, next) => {
         const rows = topTradeUps.map((t: { id: number; type: string; total_cost_cents: number; profit_cents: number; roi_percentage: number; chance_to_profit: number }) =>
           `<tr><td><a href="/trade-ups/${t.id}">${TRADE_UP_TYPE_LABELS[t.type] || t.type}</a></td><td>$${(t.total_cost_cents / 100).toFixed(2)}</td><td>$${(t.profit_cents / 100).toFixed(2)}</td><td>${t.roi_percentage?.toFixed(1)}%</td><td>${Math.round((t.chance_to_profit ?? 0) * 100)}%</td></tr>`
         ).join("");
+        const faqSchema = { "@context": "https://schema.org", "@type": "FAQPage", mainEntity: [
+          { "@type": "Question", name: "What is a CS2 trade-up contract?", acceptedAnswer: { "@type": "Answer", text: "A CS2 trade-up contract exchanges 10 weapon skins of the same rarity for 1 skin of the next higher rarity. The output is randomly selected from collections matching your inputs, weighted proportionally by input count per collection." } },
+          { "@type": "Question", name: "How does TradeUpBot find profitable trade-ups?", acceptedAnswer: { "@type": "Answer", text: "TradeUpBot scans real marketplace listings across CSFloat, DMarket, and Skinport. For each valid combination of 10 inputs, it calculates expected output value using the actual CS2 float formula and accounts for marketplace fees on both buy and sell sides." } },
+          { "@type": "Question", name: "Are these listings live?", acceptedAnswer: { "@type": "Answer", text: "Every trade-up is built from listings that existed on the marketplace at discovery time. Listings can sell before you act — use the Verify button to confirm availability before purchasing." } },
+        ] };
         const html = buildSeoHtml({
           title: "Profitable CS2 Trade-Ups — Live Contracts from Real Listings | TradeUpBot",
           description: `${profitable.toLocaleString()} profitable CS2 trade-ups from ${total.toLocaleString()} active contracts. Real listings from CSFloat, DMarket, and Skinport.`,
           url: "https://tradeupbot.app/trade-ups",
-          bodyText: `Browse ${total.toLocaleString()} active CS2 trade-up contracts. ${profitable.toLocaleString()} are currently profitable. Filter by rarity tier, ROI, profit, cost, and more.`,
-          jsonLd: { "@context": "https://schema.org", "@type": "WebApplication", name: "TradeUpBot", url: "https://tradeupbot.app/trade-ups", applicationCategory: "GameApplication", operatingSystem: "Web", description: `${profitable} profitable CS2 trade-ups from ${total} active contracts.` },
-        }).replace("</main>", `<table><thead><tr><th>Type</th><th>Cost</th><th>Profit</th><th>ROI</th><th>Chance</th></tr></thead><tbody>${rows}</tbody></table></main>`);
+          bodyHtml: `<h2>Find Profitable CS2 Trade-Up Contracts</h2><p>Browse ${total.toLocaleString()} active CS2 trade-up contracts built from real, buyable listings across all rarity tiers — Knife, Glove, Covert, Classified, Restricted, Mil-Spec. ${profitable.toLocaleString()} are currently profitable. Data sourced from CSFloat, DMarket, and Skinport with marketplace fees included.</p><table><thead><tr><th>Type</th><th>Cost</th><th>Profit</th><th>ROI</th><th>Chance</th></tr></thead><tbody>${rows}</tbody></table><section><h2>Common Questions</h2><h3>What is a CS2 trade-up contract?</h3><p>A trade-up contract exchanges 10 weapon skins of the same rarity for 1 skin of the next higher rarity. The output is randomly selected from collections matching your inputs, weighted by input count per collection.</p><h3>How does TradeUpBot find profitable trade-ups?</h3><p>TradeUpBot scans real marketplace listings across CSFloat, DMarket, and Skinport. For each valid combination of 10 inputs, it calculates expected output value using the actual CS2 float formula and accounts for marketplace fees on both the buy and sell sides.</p><h3>Are these listings live?</h3><p>Every trade-up is built from listings that existed on the marketplace at discovery time. Use the Verify button to confirm availability before purchasing inputs.</p></section>`,
+          jsonLd: [
+            { "@context": "https://schema.org", "@type": "WebApplication", name: "TradeUpBot", url: "https://tradeupbot.app/trade-ups", applicationCategory: "GameApplication", operatingSystem: "Web", description: `${profitable} profitable CS2 trade-ups from ${total} active contracts.` },
+            faqSchema,
+          ],
+        });
         try {
           const { cacheSet } = await import("./redis.js");
           await cacheSet(cacheKey, html, 3600).catch(() => {});
@@ -937,8 +945,8 @@ app.use((req, res, next) => {
         author: "TradeUpBot Team",
       },
       "cs2-trade-up-float-values-guide": {
-        title: "CS2 Trade-Up Float Formula Explained — How Adjusted Floats Actually Work",
-        excerpt: "Learn exactly how the adjusted float formula determines your output float — and why two Factory New inputs at the same price can produce wildly different results. Includes float targeting strategies you can apply immediately.",
+        title: "CS2 Float Ranges Explained: How Adjusted Float Actually Works in CS2",
+        excerpt: "CS2 float values range 0–1 and set permanent skin wear. In trade-up contracts, adjusted float — not raw float — determines your output condition. Learn the exact formula, the five condition boundaries, and float targeting strategies.",
         publishedAt: "2026-03-17",
         author: "TradeUpBot Team",
       },
@@ -949,8 +957,8 @@ app.use((req, res, next) => {
         author: "TradeUpBot Team",
       },
       "cs2-trade-up-marketplace-fees": {
-        title: "CS2 Trade-Up Fees: How Marketplace Costs Eat Your Profits",
-        excerpt: "A breakdown of CSFloat, DMarket, and Skinport fee structures — and why ignoring them turns profitable trade-ups into losses.",
+        title: "CSFloat Seller Fee (2%), DMarket & Skinport: CS2 Trade-Up Marketplace Costs",
+        excerpt: "CSFloat charges a 2% seller fee + buyer fee. DMarket: 2% seller + 2.5% buyer. Skinport: 12% seller. See how these fees affect your CS2 trade-up profitability.",
         publishedAt: "2026-03-19",
         author: "TradeUpBot Team",
       },

--- a/server/routes/listing-sniper.ts
+++ b/server/routes/listing-sniper.ts
@@ -148,8 +148,9 @@ export function listingSniperRouter(pool: pg.Pool): Router {
         if (ratio >= 1.0) continue; // Not underpriced or no KNN data
 
         const estimatedCents = Math.round(row.price_cents / ratio);
-        const diffCents = estimatedCents - row.price_cents;
+        if (estimatedCents > row.price_cents * 10) continue;
 
+        const diffCents = estimatedCents - row.price_cents;
         if (diffCents < minDiffCents) continue;
 
         results.push({

--- a/src/components/SiteNav.tsx
+++ b/src/components/SiteNav.tsx
@@ -50,8 +50,10 @@ export function SiteNav({ centerLinks }: SiteNavProps = {}) {
   const location = useLocation();
   // Initialize from localStorage to prevent flicker on navigation
   const [user, setUser] = useState<NavUser | null>(loadCachedUser);
-  const [menuOpen, setMenuOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
+  const [userMenuOpen, setUserMenuOpen] = useState(false);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const userMenuRef = useRef<HTMLDivElement>(null);
+  const mobileMenuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     fetch("/api/auth/me", { credentials: "include" })
@@ -68,15 +70,20 @@ export function SiteNav({ centerLinks }: SiteNavProps = {}) {
       .catch(() => {});
   }, []);
 
-  // Close menu on outside click
+  const navLinks = centerLinks
+    ? centerLinks.map(({ href, label }) => ({ href, label }))
+    : NAV_LINKS.map(({ to, label }) => ({ href: to, label }));
+
   useEffect(() => {
-    if (!menuOpen) return;
+    if (!userMenuOpen && !mobileMenuOpen) return;
     const handler = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setMenuOpen(false);
+      const target = e.target as Node;
+      if (userMenuRef.current && !userMenuRef.current.contains(target)) setUserMenuOpen(false);
+      if (mobileMenuRef.current && !mobileMenuRef.current.contains(target)) setMobileMenuOpen(false);
     };
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
-  }, [menuOpen]);
+  }, [userMenuOpen, mobileMenuOpen]);
 
   return (
     <nav className="fixed top-0 z-50 w-full border-b border-border bg-background/80 backdrop-blur-md">
@@ -86,23 +93,44 @@ export function SiteNav({ centerLinks }: SiteNavProps = {}) {
           <span className="hidden sm:inline">TradeUpBot</span>
         </Link>
         <div className="hidden sm:flex items-center gap-6 text-sm text-muted-foreground">
-          {centerLinks ? (
-            centerLinks.map(({ href, label }) => (
-              <a key={href} href={href} className="hover:text-foreground transition-colors">{label}</a>
-            ))
-          ) : (
-            NAV_LINKS.map(({ to, label }) => (
-              <Link
-                key={to}
-                to={to}
-                className={location.pathname.startsWith(to) ? "text-foreground transition-colors" : "hover:text-foreground transition-colors"}
-              >
-                {label}
-              </Link>
-            ))
-          )}
+          {navLinks.map(({ href, label }) => (
+            <a
+              key={href}
+              href={href}
+              className={location.pathname.startsWith(href) ? "text-foreground transition-colors" : "hover:text-foreground transition-colors"}
+            >
+              {label}
+            </a>
+          ))}
         </div>
         <div className="flex items-center gap-2 sm:gap-3 shrink-0 justify-self-end">
+          <div className="relative sm:hidden" ref={mobileMenuRef}>
+            <button
+              onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+              aria-label="Open navigation menu"
+              className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-border text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                <line x1="3" y1="6" x2="21" y2="6" />
+                <line x1="3" y1="12" x2="21" y2="12" />
+                <line x1="3" y1="18" x2="21" y2="18" />
+              </svg>
+            </button>
+            {mobileMenuOpen && (
+              <div className="absolute right-0 top-full mt-1 w-44 rounded-lg border border-border bg-card shadow-xl z-50 py-1">
+                {navLinks.map(({ href, label }) => (
+                  <a
+                    key={href}
+                    href={href}
+                    onClick={() => setMobileMenuOpen(false)}
+                    className="block px-3 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                  >
+                    {label}
+                  </a>
+                ))}
+              </div>
+            )}
+          </div>
           <CurrencyPicker />
           {user ? (
             <>
@@ -112,9 +140,9 @@ export function SiteNav({ centerLinks }: SiteNavProps = {}) {
               >
                 Dashboard
               </Link>
-              <div className="relative" ref={menuRef}>
+              <div className="relative" ref={userMenuRef}>
                 <button
-                  onClick={() => setMenuOpen(!menuOpen)}
+                  onClick={() => setUserMenuOpen(!userMenuOpen)}
                   className="flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer rounded-md px-2 py-1.5 hover:bg-muted"
                 >
                   {user.avatar_url && <img src={user.avatar_url} className="w-5 h-5 rounded-full" alt="" />}
@@ -124,7 +152,7 @@ export function SiteNav({ centerLinks }: SiteNavProps = {}) {
                   </span>
                   <span className="text-muted-foreground/50 text-[10px]">&#9662;</span>
                 </button>
-                {menuOpen && (
+                {userMenuOpen && (
                   <div className="absolute right-0 top-full mt-1 w-48 bg-card border border-border rounded-lg shadow-xl z-50 py-1">
                     <div className="px-3 py-2 border-b border-border">
                       <div className="text-sm font-medium">{user.display_name}</div>

--- a/src/data/blog-posts.ts
+++ b/src/data/blog-posts.ts
@@ -159,8 +159,8 @@ export const blogPosts: BlogPost[] = [
   },
   {
     slug: "cs2-trade-up-float-values-guide",
-    title: "CS2 Trade-Up Float Formula Explained — How Adjusted Floats Actually Work",
-    excerpt: "Learn exactly how the adjusted float formula determines your output float — and why two Factory New inputs at the same price can produce wildly different results. Includes float targeting strategies you can apply immediately.",
+    title: "CS2 Float Ranges Explained: How Adjusted Float Actually Works in CS2",
+    excerpt: "CS2 float values range 0–1 and set permanent skin wear. In trade-up contracts, adjusted float — not raw float — determines your output condition. Learn the exact formula, the five condition boundaries, and float targeting strategies.",
     publishedAt: "2026-03-17",
     readTime: "7 min read",
     author: "TradeUpBot Team",
@@ -328,8 +328,8 @@ Skin B's adjusted float: 0.03 / 0.08 = 0.375</p>
   },
   {
     slug: "cs2-trade-up-marketplace-fees",
-    title: "CS2 Trade-Up Fees: How Marketplace Costs Eat Your Profits",
-    excerpt: "A breakdown of CSFloat, DMarket, and Skinport fee structures — and why ignoring them turns profitable trade-ups into losses.",
+    title: "CSFloat Seller Fee (2%), DMarket & Skinport: CS2 Trade-Up Marketplace Costs",
+    excerpt: "CSFloat charges a 2% seller fee + buyer fee. DMarket: 2% seller + 2.5% buyer. Skinport: 12% seller. See how these fees affect your CS2 trade-up profitability.",
     publishedAt: "2026-03-19",
     readTime: "5 min read",
     author: "TradeUpBot Team",

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -107,10 +107,10 @@ const LandingPage = ({ user }: { user?: LandingUser | null }) => {
       </Helmet>
 
       <SiteNav centerLinks={[
-        { href: "#features", label: "Features" },
-        { href: "#pricing", label: "Pricing" },
-        { href: "#faq", label: "FAQ" },
-        { href: "#blog", label: "Blog" },
+        { href: "/features", label: "Features" },
+        { href: "/pricing", label: "Pricing" },
+        { href: "/faq", label: "FAQ" },
+        { href: "/blog", label: "Blog" },
       ]} />
 
       <main>
@@ -134,9 +134,9 @@ const LandingPage = ({ user }: { user?: LandingUser | null }) => {
                   </Btn>
                 ) : (
                   <>
-                    <Btn onClick={() => { window.location.href = '/trade-ups'; }} className="px-6 py-3">
+                    <a href="/trade-ups" className="inline-flex items-center justify-center gap-2 px-6 py-3 text-sm font-medium rounded-lg transition-all cursor-pointer bg-foreground text-background hover:bg-foreground/90">
                       View Trade-Ups
-                    </Btn>
+                    </a>
                     <span className="text-xs text-muted-foreground">Free — no account needed</span>
                   </>
                 )}
@@ -199,18 +199,18 @@ const LandingPage = ({ user }: { user?: LandingUser | null }) => {
               <div>
                 <h2 className="text-2xl font-bold mb-3">Outcome analysis</h2>
                 <p className="text-muted-foreground mb-6">Every possible outcome with probabilities, expected value, and the exact inputs needed. Claim to lock listings for 30 minutes while you buy.</p>
-                <img src="/expanded.png" alt="Trade-up outcomes" className="rounded-lg border border-border w-full" />
+                <img src="/expanded.png" alt="Trade-up outcomes" loading="lazy" width="2596" height="1822" className="rounded-lg border border-border w-full" />
               </div>
               <div>
                 <h2 className="text-2xl font-bold mb-3">Price intelligence</h2>
                 <p className="text-muted-foreground mb-6">Float vs price scatter charts with data from CSFloat, DMarket, Skinport, and sale history across every condition.</p>
-                <img src="/dataviewer.png" alt="Price data" className="rounded-lg border border-border w-full" />
+                <img src="/dataviewer.png" alt="Price data" loading="lazy" width="2434" height="1498" className="rounded-lg border border-border w-full" />
               </div>
             </div>
             <div>
               <h2 className="text-2xl font-bold mb-3">89 collections covered</h2>
               <p className="text-muted-foreground mb-6">Browse every collection with knife/glove pool info, listing counts, and profitable trade-ups. Filter by knives, gloves, or profitability.</p>
-              <img src="/collections.png" alt="Collections" className="rounded-lg border border-border w-full" />
+              <img src="/collections.png" alt="Collections" loading="lazy" width="2624" height="1608" className="rounded-lg border border-border w-full" />
             </div>
             <div className="text-center mt-10">
               <a href="/features" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
@@ -414,9 +414,9 @@ const LandingPage = ({ user }: { user?: LandingUser | null }) => {
             <div>
               <div className="text-xs uppercase tracking-wider text-muted-foreground/50 mb-3">Product</div>
               <div className="space-y-2 text-sm">
-                <a href="#features" className="block text-muted-foreground hover:text-foreground transition-colors">Features</a>
-                <a href="#pricing" className="block text-muted-foreground hover:text-foreground transition-colors">Pricing</a>
-                <a href="#faq" className="block text-muted-foreground hover:text-foreground transition-colors">FAQ</a>
+                <a href="/features" className="block text-muted-foreground hover:text-foreground transition-colors">Features</a>
+                <a href="/pricing" className="block text-muted-foreground hover:text-foreground transition-colors">Pricing</a>
+                <a href="/faq" className="block text-muted-foreground hover:text-foreground transition-colors">FAQ</a>
                 <a href="/blog" className="block text-muted-foreground hover:text-foreground transition-colors">Blog</a>
               </div>
             </div>
@@ -430,7 +430,7 @@ const LandingPage = ({ user }: { user?: LandingUser | null }) => {
             <div>
               <div className="text-xs uppercase tracking-wider text-muted-foreground/50 mb-3">Contact</div>
               <div className="space-y-2 text-sm">
-                <a href="https://discord.gg/tradeupbot" target="_blank" rel="noopener noreferrer" className="block text-muted-foreground hover:text-foreground transition-colors">Discord</a>
+                <a href="https://discord.gg/gQ8cPqBq2a" target="_blank" rel="noopener noreferrer" className="block text-muted-foreground hover:text-foreground transition-colors">Discord</a>
               </div>
             </div>
           </div>

--- a/src/pages/ListingSniperPage.tsx
+++ b/src/pages/ListingSniperPage.tsx
@@ -463,7 +463,7 @@ export function ListingSniperPage() {
                 </div>
                 <div className="mt-2">
                   <a
-                    href={listingUrl(listing.id, listing.skin_name, listing.condition, listing.float_value, listing.listed_price_cents, listing.source, listing.marketplace_id ?? undefined)}
+                    href={listingUrl(listing.id, listing.skin_name, listing.condition, listing.float_value, listing.listed_price_cents, listing.source, listing.marketplace_id ?? undefined, listing.stattrak)}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-blue-400 hover:text-blue-300 text-[0.7rem]"
@@ -531,7 +531,7 @@ export function ListingSniperPage() {
                     </td>
                     <td className="py-2.5 text-right">
                       <a
-                        href={listingUrl(listing.id, listing.skin_name, listing.condition, listing.float_value, listing.listed_price_cents, listing.source, listing.marketplace_id ?? undefined)}
+                        href={listingUrl(listing.id, listing.skin_name, listing.condition, listing.float_value, listing.listed_price_cents, listing.source, listing.marketplace_id ?? undefined, listing.stattrak)}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="text-blue-400 hover:text-blue-300 text-[0.7rem] whitespace-nowrap"

--- a/src/pages/ListingSniperPage.tsx
+++ b/src/pages/ListingSniperPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
+import { Helmet } from "react-helmet-async";
 import { Badge } from "@shared/components/ui/badge.js";
 import { Button } from "@shared/components/ui/button.js";
 import { Input } from "@shared/components/ui/input.js";
@@ -346,6 +347,15 @@ export function ListingSniperPage() {
 
   return (
     <>
+      <Helmet>
+        <title>Listing Sniper | TradeUpBot</title>
+      </Helmet>
+
+      <div className="mb-4">
+        <h1 className="text-2xl font-bold text-foreground">Listing Sniper</h1>
+        <p className="text-sm text-muted-foreground mt-1">Listings priced below estimated market value, sorted by discount percentage.</p>
+      </div>
+
       <div className="flex items-center gap-3 mb-3 flex-wrap">
         <div className="flex-1 min-w-0">
           <div className="flex gap-2.5 items-center flex-wrap">

--- a/src/pages/TradeUpsPage.tsx
+++ b/src/pages/TradeUpsPage.tsx
@@ -194,7 +194,36 @@ export function TradeUpsPage({ types, defaultType, status, refreshKey, onNavigat
           "operatingSystem": "Web",
           "description": "Find profitable CS2 trade-up contracts using real marketplace listings."
         })}</script>
+        <script type="application/ld+json">{JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "FAQPage",
+          "mainEntity": [
+            {
+              "@type": "Question",
+              "name": "What is a CS2 trade-up contract?",
+              "acceptedAnswer": { "@type": "Answer", "text": "A CS2 trade-up contract exchanges 10 weapon skins of the same rarity for 1 skin of the next higher rarity. The output is randomly selected from collections matching your inputs, weighted by input count per collection." }
+            },
+            {
+              "@type": "Question",
+              "name": "How does TradeUpBot find profitable trade-ups?",
+              "acceptedAnswer": { "@type": "Answer", "text": "TradeUpBot scans real marketplace listings across CSFloat, DMarket, and Skinport. For each valid combination of 10 inputs, it calculates expected output value using the actual float formula and accounts for marketplace fees on both the buy and sell sides." }
+            },
+            {
+              "@type": "Question",
+              "name": "Are these listings live?",
+              "acceptedAnswer": { "@type": "Answer", "text": "Every trade-up is built from listings that existed on the marketplace at discovery time. Listings can sell before you act — use the Verify button to confirm availability before purchasing." }
+            }
+          ]
+        })}</script>
       </Helmet>
+
+      <section className="mb-5">
+        <h2 className="text-base font-semibold mb-1.5">Find Profitable CS2 Trade-Up Contracts</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          Browse profitable CS2 trade-up contracts built from real, buyable listings across all rarity tiers — Knife, Glove, Covert, Classified, Restricted, Mil-Spec. Every entry uses live pricing from CSFloat, DMarket, and Skinport with marketplace fees already factored in.
+        </p>
+      </section>
+
       {/* Type selector + Your Claims button */}
       {types.length > 1 && (
         <div className="flex items-center gap-1.5 md:gap-2 mb-3 flex-wrap">
@@ -307,6 +336,24 @@ export function TradeUpsPage({ types, defaultType, status, refreshKey, onNavigat
           )}
         </div>
       )}
+
+      <section className="mt-10 pt-8 border-t border-border/40">
+        <h2 className="text-sm font-semibold mb-4 text-muted-foreground uppercase tracking-wide">Common Questions</h2>
+        <div className="space-y-5">
+          <div>
+            <h3 className="text-sm font-medium mb-1">What is a CS2 trade-up contract?</h3>
+            <p className="text-sm text-muted-foreground leading-relaxed">A trade-up contract exchanges 10 weapon skins of the same rarity for 1 skin of the next higher rarity. The output is randomly selected from collections matching your inputs, weighted proportionally by how many inputs came from each collection.</p>
+          </div>
+          <div>
+            <h3 className="text-sm font-medium mb-1">How does TradeUpBot find profitable trade-ups?</h3>
+            <p className="text-sm text-muted-foreground leading-relaxed">TradeUpBot scans real marketplace listings across CSFloat, DMarket, and Skinport. For each valid combination of 10 inputs, it calculates the expected output value using the actual CS2 float formula and accounts for marketplace fees on both the buy and sell sides — only surfaces contracts where the numbers work.</p>
+          </div>
+          <div>
+            <h3 className="text-sm font-medium mb-1">Are these listings live?</h3>
+            <p className="text-sm text-muted-foreground leading-relaxed">Every trade-up is built from listings that existed on the marketplace at discovery time. Listings can sell before you act — use the Verify button to confirm availability and current prices before purchasing inputs.</p>
+          </div>
+        </div>
+      </section>
     </>
   );
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -63,7 +63,7 @@ export function listingSource(listingId: string, source?: string): "csfloat" | "
 /** Source-aware listing URL — routes to the correct marketplace with float/price filters.
  *  priceCents is the EFFECTIVE cost (with buyer fees). The URL uses the ORIGINAL listing
  *  price (without fees) so price filters target the exact listing on the marketplace. */
-export function listingUrl(listingId: string, skinName?: string, condition?: string, floatValue?: number, priceCents?: number, sourceHint?: string, marketplaceId?: string): string {
+export function listingUrl(listingId: string, skinName?: string, condition?: string, floatValue?: number, priceCents?: number, sourceHint?: string, marketplaceId?: string, stattrak?: boolean): string {
   const source = listingSource(listingId, sourceHint);
   if (source === "buff") {
     // Buff can't deep-link to a specific listing — link to the goods page
@@ -75,7 +75,7 @@ export function listingUrl(listingId: string, skinName?: string, condition?: str
     // Float has 3-digit precision — floor/ceil at 3rd decimal to bracket the exact listing.
     // e.g. float 0.2819 → floatValueFrom=0.281, floatValueTo=0.282
     const params = new URLSearchParams({ title: skinName ?? "" });
-    params.set("category_0", "not_stattrak_tm");
+    params.set("category_0", stattrak ? "stattrak_tm" : "not_stattrak_tm");
     if (floatValue !== undefined && floatValue > 0) {
       const lower = Math.floor(floatValue * 1000) / 1000;
       const upper = lower + 0.001;

--- a/tests/integration/listing-sniper.test.ts
+++ b/tests/integration/listing-sniper.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import request from "supertest";
+import { createTestApp, type TestContext } from "./setup.js";
+
+vi.mock("../../server/engine.js", () => ({
+  batchInputValueRatios: vi.fn(async () => new Map<string, number>([
+    ["good-listing", 0.5],
+    ["junk-listing", 0.01],
+  ])),
+}));
+
+import { listingSniperRouter } from "../../server/routes/listing-sniper.js";
+
+describe("Listing sniper route", () => {
+  let ctx: TestContext;
+
+  beforeAll(async () => {
+    ctx = await createTestApp();
+
+    await ctx.pool.query(
+      `INSERT INTO skins (id, name, weapon, rarity, min_float, max_float)
+       VALUES
+         ('skin-1', 'AK-47 | Test Skin', 'AK-47', 'Classified', 0.0, 1.0),
+         ('skin-2', 'M4A4 | Test Skin', 'M4A4', 'Classified', 0.0, 1.0)`
+    );
+
+    await ctx.pool.query(
+      `INSERT INTO listings (id, skin_id, price_cents, float_value, source, listing_type)
+       VALUES
+         ('good-listing', 'skin-1', 100, 0.2, 'csfloat', 'buy_now'),
+         ('junk-listing', 'skin-2', 8, 0.7, 'csfloat', 'buy_now')`
+    );
+
+    ctx.app.use(listingSniperRouter(ctx.pool));
+  });
+
+  afterAll(async () => {
+    await ctx.cleanup();
+  });
+
+  it("filters out implausible estimates above 10x listing price", async () => {
+    const res = await request(ctx.app).get("/api/listing-sniper");
+
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(1);
+    expect(res.body.listings).toHaveLength(1);
+    expect(res.body.listings[0].id).toBe("good-listing");
+  });
+});

--- a/tests/unit/dmarket-url.test.ts
+++ b/tests/unit/dmarket-url.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { listingUrl } from "../../src/utils/format.js";
+
+describe("listingUrl dmarket StatTrak filter", () => {
+  it("uses stattrak filter for StatTrak listings", () => {
+    const url = listingUrl(
+      "dmarket:test",
+      "StatTrak™ Glock-18 | Winterized",
+      "Field-Tested",
+      0.2819,
+      1234,
+      "dmarket",
+      undefined,
+      true,
+    );
+
+    expect(url).toContain("category_0=stattrak_tm");
+    expect(url).toContain("floatValueFrom=0.281");
+    expect(url).toContain("floatValueTo=0.282");
+  });
+
+  it("keeps non-StatTrak filter for normal listings", () => {
+    const url = listingUrl(
+      "dmarket:test",
+      "Glock-18 | Winterized",
+      "Field-Tested",
+      0.2819,
+      1234,
+      "dmarket",
+      undefined,
+      false,
+    );
+
+    expect(url).toContain("category_0=not_stattrak_tm");
+  });
+});

--- a/tests/unit/landing-page-links.test.ts
+++ b/tests/unit/landing-page-links.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const landingPageSource = readFileSync(resolve(testDir, "../../src/pages/LandingPage.tsx"), "utf8");
+const siteNavSource = readFileSync(resolve(testDir, "../../src/components/SiteNav.tsx"), "utf8");
+
+describe("landing page link targets", () => {
+  it("uses route links instead of hash anchors for nav and footer", () => {
+    expect(landingPageSource).toContain('{ href: "/features", label: "Features" }');
+    expect(landingPageSource).toContain('{ href: "/pricing", label: "Pricing" }');
+    expect(landingPageSource).toContain('{ href: "/faq", label: "FAQ" }');
+    expect(landingPageSource).toContain('{ href: "/blog", label: "Blog" }');
+    expect(landingPageSource).not.toContain('href="#features"');
+    expect(landingPageSource).not.toContain('href="#pricing"');
+    expect(landingPageSource).not.toContain('href="#faq"');
+    expect(landingPageSource).not.toContain('href="#blog"');
+  });
+
+  it("uses consistent discord invite and anchor CTA for trade-ups", () => {
+    expect(landingPageSource).toContain('href="https://discord.gg/gQ8cPqBq2a"');
+    expect(landingPageSource).not.toContain("discord.gg/tradeupbot");
+    expect(landingPageSource).toContain('<a href="/trade-ups"');
+    expect(landingPageSource).toContain("View Trade-Ups");
+  });
+
+  it("adds lazy loading and explicit dimensions to marketing screenshots", () => {
+    expect(landingPageSource).toContain('src="/expanded.png" alt="Trade-up outcomes" loading="lazy" width="2596" height="1822"');
+    expect(landingPageSource).toContain('src="/dataviewer.png" alt="Price data" loading="lazy" width="2434" height="1498"');
+    expect(landingPageSource).toContain('src="/collections.png" alt="Collections" loading="lazy" width="2624" height="1608"');
+  });
+});
+
+describe("site nav mobile menu", () => {
+  it("includes a mobile navigation trigger button", () => {
+    expect(siteNavSource).toContain('aria-label="Open navigation menu"');
+    expect(siteNavSource).toContain("sm:hidden");
+  });
+});


### PR DESCRIPTION
## Summary
This PR delivers the architected integration plan for audit-tradeupbot issues **#84 through #104** as one merged bugbash branch.

Plan followed:
- Enumerate open issues and prioritize by severity (P0 → P3)
- Execute one-fix-per-issue as dynamic DAG nodes
- Limit parallelism to avoid CPU contention
- Land minimal patches with targeted tests per node

## Node deliveries (from coder handoffs)

### 1) Listing Sniper node (issues #85, #90, #91)
- Fixed DMarket StatTrak category mapping in listing URLs
- Added Listing Sniper page H1/title/description metadata
- Added server-side filter to drop implausible estimates (>10x listed price)
- Tests:
  - `tests/unit/dmarket-url.test.ts`
  - `tests/integration/listing-sniper.test.ts`

### 2) Landing/Nav UX + SEO node (issues #87, #88, #92, #98, #99, #103)
- Replaced landing hash links with real crawlable routes (`/features`, `/pricing`, `/faq`, `/blog`)
- Added mobile hamburger dropdown in `SiteNav` for small screens
- Converted hero CTA to anchor (`/trade-ups`)
- Unified Discord URL
- Added lazy-loading + dimensions on below-the-fold landing screenshots
- Tests:
  - `tests/unit/landing-page-links.test.ts`

### 3) Content SEO node (issues #96, #97)
- Updated two blog titles/excerpts for clearer intent/CTR
- Added `/trade-ups` intro + FAQ content
- Added FAQPage JSON-LD in client and crawler SSR HTML
- Synced blog metadata in both client data and server SSR metadata mirror
- Validation:
  - `tsc --noEmit`
  - unit suite run (with documented unrelated pre-existing failures)

### 4) Server SEO/Sitemap node (issues #93, #94, #95, #100, #101, #102)
- Fixed homepage duplicate title behavior for crawler/non-crawler paths
- Removed stale trade-up IDs from sitemap index (`sitemap-tradeups.xml` now empty and not indexed)
- Fixed blog canonical trailing slash consistency
- Filtered collection sitemaps to actual trade-up-capable weapon collections
- Added DB fallback for homepage stats when Redis cache is cold
- Confirmed non-www canonical consistency
- Tests:
  - `tests/integration/seo.test.ts` (expanded coverage)
  - `tests/unit/sitemap.test.ts` update

### 5) Perf/code-splitting node (issue #104)
- Route-based lazy loading for heavyweight routes in `src/App.tsx`
- Preserved existing routing/layout semantics with Suspense boundaries
- Build/typecheck validation performed (`npm run build`, `tsc --noEmit`)

## Notes
- Several handoffs note existing unrelated baseline test/schema failures in full-suite runs; node-specific tests and validations were executed and documented per change.
- Issues are referenced in commits; this PR does **not** auto-close issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added mobile navigation menu with hamburger button.
  * Added FAQ section to Trade-Ups page with enhanced search engine structured data.
  * Added page heading and description to Listing Sniper page.

* **Improvements**
  * Enhanced filtering of listings with unrealistic price estimates.
  * Improved StatTrak category handling for marketplace links.
  * Added lazy-loading and optimized images on landing page.

* **Updates**
  * Updated blog post metadata for clarity.
  * Converted navigation links to path-based routing for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->