### PR TITLE
fix(seo): dedupeHead keeps last tag occurrence (#111 hotfix)

### DIFF
--- a/server/seo.ts
+++ b/server/seo.ts
@@ -75,7 +75,7 @@ export function dedupeHead(html: string): string {
       if (candidates.length <= 1) continue;
 
       const helmetCandidate = candidates.find((entry) => /\sdata-rh=(['"])true\1/i.test(entry.tag));
-      const keep = helmetCandidate || candidates[0];
+      const keep = helmetCandidate || candidates[candidates.length - 1];
 
       for (const entry of candidates) {
         if (entry.start !== keep.start) remove.add(entry.start);

--- a/tests/unit/seo-head-dedupe.test.ts
+++ b/tests/unit/seo-head-dedupe.test.ts
@@ -37,6 +37,38 @@ describe("dedupeHead on realistic prerender capture (#1)", () => {
   });
 });
 
+describe("dedupeHead with react-helmet-async@3 output (no data-rh attribute)", () => {
+  it("keeps last occurrence when helmet tags don't have data-rh — helmet appends to head", () => {
+    // Real react-helmet-async@3 output: tags appear at end of head WITHOUT data-rh attribute.
+    // dedupeHead must keep the LAST occurrence (helmet's append) not the FIRST (template).
+    const html = `<!DOCTYPE html><html lang="en"><head>
+<link rel="canonical" href="https://tradeupbot.app/">
+<title>TradeUpBot — Find Profitable CS2 Trade-Ups from Real Listings</title>
+<meta name="description" content="Real-time CS2 trade-up contract analyzer.">
+<meta property="og:title" content="TradeUpBot — Find Profitable CS2 Trade-Ups from Real Listings">
+<meta property="og:url" content="https://tradeupbot.app">
+<title>CS2 Float Values Guide | TradeUpBot Blog</title>
+<meta name="description" content="CS2 float values explained.">
+<link rel="canonical" href="https://tradeupbot.app/blog/cs2-trade-up-float-values-guide/">
+<meta property="og:title" content="CS2 Float Values Guide | TradeUpBot Blog">
+<meta property="og:url" content="https://tradeupbot.app/blog/cs2-trade-up-float-values-guide/">
+</head><body></body></html>`;
+
+    const out = dedupeHead(html);
+
+    expect((out.match(/<title[^>]*>/g) ?? []).length).toBe(1);
+    expect((out.match(/rel="canonical"/g) ?? []).length).toBe(1);
+    expect((out.match(/property="og:title"/g) ?? []).length).toBe(1);
+    expect((out.match(/property="og:url"/g) ?? []).length).toBe(1);
+
+    // The blog-post tags appear AFTER the template tags in head — must be kept.
+    expect(out).toContain("CS2 Float Values Guide");
+    expect(out).toContain("blog/cs2-trade-up-float-values-guide/");
+    expect(out).not.toContain("Find Profitable CS2 Trade-Ups from Real Listings");
+    expect(out).not.toContain('content="https://tradeupbot.app"');
+  });
+});
+
 describe("index.html og:title matches title (#12)", () => {
   it("og:title equals title in index.html template", () => {
     const html = readFileSync(join(__dir, "../../index.html"), "utf-8");


### PR DESCRIPTION
## Bug

PR #111's \`dedupeHead\` keeps the WRONG tag on prerendered blog pages — the homepage canonical/title/description instead of the per-route blog tags.

**Live evidence (\`curl https://tradeupbot.app/blog/cs2-trade-up-float-values-guide/\` initial HTML):**
\`\`\`
<link rel="canonical" href="https://tradeupbot.app/">
<title>TradeUpBot — Find Profitable CS2 Trade-Ups from Real Listings</title>
\`\`\`

The blog post's canonical should be \`https://tradeupbot.app/blog/cs2-trade-up-float-values-guide/\` and title \`CS2 Float Ranges Explained: How Adjusted Float Actually Works in CS2\`. Instead it points to the homepage. **Google is now consolidating ALL blog post authority to the homepage canonical** — worse than the original duplicate-canonical bug (where at least one of the duplicates was correct).

## Root cause

\`dedupeHead\` prefers tags with \`data-rh="true"\` (react-helmet's marker). But **react-helmet-async@3 stopped emitting \`data-rh\` attributes**. The regex never matches on real prerendered output, so the fallback \`keep = candidates[0]\` triggers — the FIRST occurrence, which is always the SPA template tag (template tags appear before helmet's appended tags in head).

## Fix

One-line change: \`candidates[0]\` → \`candidates[candidates.length - 1]\` in the fallback. Helmet appends to head, so the LAST occurrence is always the helmet-injected one when no \`data-rh\` marker is present.

Added regression test that simulates real helmet-async@3 output (no \`data-rh\` attribute) and verifies the blog tags win over the template tags.

## Test plan

- [x] \`bun test tests/unit/seo-head-dedupe.test.ts\` — 3 pass (was 2)
- [x] \`bun test tests/unit/seo-*.test.ts\` — 16 pass
- [ ] After merge + deploy: \`curl https://tradeupbot.app/blog/cs2-trade-up-float-values-guide/ | grep -E "canonical|title"\` should show the blog-specific values
- [ ] After deploy: re-trigger GSC re-crawl on a few blog URLs and verify they re-index under their own canonical (1-2 weeks)

## Why this matters

The monitoring loop set up earlier (\`.monitoring/monitoring-2026-05-04-seo-fixes-2026-05-04.md\`) flagged that \`#2 blog canonical\` was set client-side by React. That flag was the symptom — this is the cause. Without this fix, the SEO recovery from PR #111 will be net-negative because authority consolidates to homepage on JS-disabled crawler views.