### PR TITLE
fix: pluralize 'knife' as 'knives' on collections page (closes #86)

### DIFF
--- a/src/components/CollectionListViewer.tsx
+++ b/src/components/CollectionListViewer.tsx
@@ -152,7 +152,7 @@ export function CollectionListViewer({ onSelectCollection }: { onSelectCollectio
                       variant="outline"
                       className="text-[0.65rem] bg-blue-400/10 text-blue-400 border-blue-400/25"
                     >
-                      {c.knife_type_count} knife{c.knife_type_count !== 1 ? "s" : ""}
+                      {c.knife_type_count} {c.knife_type_count === 1 ? "knife" : "knives"}
                     </Badge>
                   )}
                   {c.has_gloves && (


### PR DESCRIPTION
## Summary
- The collections list rendered '5 knifes' / '4 knifes' on cards because `CollectionListViewer.tsx` appended `s` to `knife` for plural counts.
- Fix uses the proper irregular plural: `knife` when count === 1, otherwise `knives`.

Closes #86.

## Test plan
- [ ] Visit `/collections` and confirm card badges read e.g. `5 knives`, `1 knife`.