### PR TITLE
docs: refresh CLAUDE.md (root + nested) + AGENTS.md symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ improvements.md
 overnight_tracking.md
 notes.md
 RESEARCH.md
-CLAUDE.md
 deployment.md
 optimizations.md
 overnight-notes.md
@@ -36,8 +35,7 @@ scaling.md
 .DS_Store
 Thumbs.db
 
-# CLAUDE.md and docs
-server/**/CLAUDE.md
+# Docs
 docs/
 
 # Content production (raw footage, edited video, screenshots)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# Trade-Up Bot
+
+CS2 trade-up contract analyzer. Discovers and ranks profitable 10-skin → 1-skin trade-ups across six rarity tiers by combining live market data (CSFloat sales, DMarket listings, Skinport WebSocket, Buff.market) with a deterministic output-float model and KNN float-sensitive pricing.
+
+## Stack
+- Node.js ESM + Express on port 3001 (no build step — `tsx` runs TS directly)
+- React 19 + Vite on port 5173 (proxies API in dev)
+- PostgreSQL 16 (`tradeupbot`) via async `pg` Pool
+- Redis (route cache + claim TTLs); SQLite for sessions (`data/sessions.db`)
+- Deployed to a Hetzner VPS via PM2
+
+## Layout
+- `server/` — API + daemon + engine + data fetchers
+  - `engine/` — math, EV, KNN pricing, knife/glove specials → see `server/engine/CLAUDE.md`
+  - `routes/` — REST API, claims, verify, Stripe → see `server/routes/CLAUDE.md`
+  - `daemon/` — time-bounded discovery loop with forked workers → see `server/daemon/CLAUDE.md`
+  - `sync/` — CSFloat / DMarket / Skinport / Buff fetchers → see `server/sync/CLAUDE.md`
+- `src/` — React frontend (App.tsx, pages/, components/, contexts/, hooks/)
+- `shared/types.ts` — cross-layer types
+- `tests/` — `unit/`, `integration/`, `stress/`, `helpers/fixtures.ts`
+
+## Running
+
+```bash
+# API server (auto-reloads)
+npx tsx watch server/index.ts
+
+# Daemon (background data fetch + discovery, resumes existing data)
+NODE_OPTIONS="--max-old-space-size=8192" npx tsx server/daemon.ts
+
+# Daemon with fresh start (purges all trade-ups + flushes Redis cache)
+NODE_OPTIONS="--max-old-space-size=8192" npx tsx server/daemon.ts --fresh
+
+# Frontend dev server (also runs API server via concurrently)
+npm run dev
+```
+
+## Coding Conventions
+- TypeScript ESM imports use `.js` extension (resolved at runtime by tsx / Node ESM).
+- No `as any` or `as unknown as` casts.
+- PostgreSQL via async `pg` Pool with `$1, $2` placeholders.
+- Boolean SQL columns (`stattrak`, `souvenir`, `is_admin`): `= true` / `= false` in SQL, JS booleans as params.
+- Redis ops awaited before API responses.
+- **Prices are integer cents throughout** — never fractional dollars.
+
+## Import Rules
+- Barrel pattern: import from `./engine.js` and `./sync.js`. Never reach into `./engine/<submodule>.js` from outside the package.
+- `engine/db-ops.ts` is a barrel for `db-save.ts`, `db-status.ts`, `db-revive.ts`, `db-stats.ts`.
+- `CONDITION_BOUNDS` from `engine/types.ts` — never hardcode float ranges.
+- Shared utilities from `engine/utils.ts`: `pick`, `shuffle`, `listingSig`, `parseSig`, `computeChanceToProfit`, `computeBestWorstCase`, `withRetry`, `pickWeightedStrategy`.
+
+## Testing & TDD
+- **TDD is mandatory.** Red / green / refactor.
+- Pre-push hook runs `tsc --noEmit` + vitest (unit + integration). Don't skip it.
+
+### Project-specific TDD conventions
+- **Runner**: vitest. Run with `npx vitest run <path>`. Never jest.
+- **Fixtures**: always use `tests/helpers/fixtures.ts` — `makeListing()`, `makeAdjustedListing()`, `makeListings(n)`, `makeOutcome()`, `makeTradeUp()`, `makeObservation()`. Never redeclare locally.
+- **Test placement**:
+  - Pure logic → `tests/unit/<module>.test.ts`
+  - Needs PostgreSQL → `tests/integration/<feature>.test.ts` (uses `tradeupbot_test` DB, see `tests/integration/setup.ts`)
+  - Performance → `tests/stress/`
+  - Property-based → `tests/unit/properties/<module>.prop.test.ts` (use `fast-check`)
+- **Property tests** cover invariants: prices in integer cents, probabilities sum to 1, float ranges within bounds, ROI math consistency.
+- **Verify commands**: `npm run test:unit` (fast), `npm test` (unit + integration), `npm run typecheck`.
+
+## Daemon Deploy
+- Code changes require a hard restart: `pm2 restart daemon` (running process holds old code in memory).
+- Fresh restart (purge + restart): `scripts/daemon-fresh.sh`.
+
+## Git
+- No `Co-Authored-By` trailers or Claude/Anthropic attribution in commits.
+- Don't modify `git config user.email` or `user.name`.

--- a/server/daemon/AGENTS.md
+++ b/server/daemon/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/server/daemon/CLAUDE.md
+++ b/server/daemon/CLAUDE.md
@@ -1,0 +1,53 @@
+# Daemon Reference
+
+Time-bounded discovery engine. `TARGET_CYCLE_MS = 30 min` (matches Basic-tier delay).
+
+## Cycle Phases (`server/daemon/index.ts`)
+1. **Phase 1 — Housekeeping**: purge stale listings, refresh listing statuses, prune observations.
+2. **Phase 3 — API Probe**: rate-limit detection across all 3 CSFloat pools.
+3. **Phase 4 — Data Fetch**: round-robin sale history + listings (skipped if all pools rate-limited).
+4. **Phase 4b — Recalc**: trade-up costs where input prices changed (DMarket/Skinport updates).
+5. **Phase 4c — Reprice**: 20K trade-up outputs with current KNN + price cache (profitable first, then oldest).
+6. **Phase 5 — Time-Bounded Engine**: all remaining time, ends 30s before cycle deadline. Repeating super-batches; each batch runs `WORKER_ROUNDS`:
+    - knife + classified
+    - knife + restricted
+    - milspec + industrial
+    - consumer (alone)
+   Then merge → revival (1000 knife + 1000 per gun type) → expired-claim cleanup → DMarket staleness (every other batch).
+
+CSFloat individual-pool staleness checks run in a **separate** `csfloat-checker` process — not in this daemon.
+
+## Workers (`calc-worker.ts`)
+Forked child processes (`fork()`), read-only DB. Each worker:
+1. Loads existing signatures from DB.
+2. Structured discovery with deadline (~60% of time budget).
+3. Deep exploration with the remainder.
+4. Returns results via NDJSON over stdout.
+
+Time limits (`MIN_WORKER_TIME = 3 min`, `MAX_WORKER_TIME = 5 min`): the first super-batch divides remaining time across rounds (capped at MAX); later super-batches use MIN. SIGTERM at `workerTimeLimit + 30s` (`WORKER_KILL_BUFFER`).
+
+NDJSON pre-materialization: main process writes `/tmp/discovery-data-<rarity>-<key>.ndjson`; workers read the file instead of re-querying Postgres (~15s saved per worker).
+
+## Files
+- `index.ts` — main cycle loop, `WORKER_ROUNDS`, `TASK_TYPE_MAP`, super-batch driver.
+- `calc-worker.ts` — forked child that runs discovery for one tier.
+- `state.ts` — `BudgetTracker`, `FreshnessTracker`, `TARGET_CYCLE_MS`, safety buffers.
+- `utils.ts` — logging, rate-limit detection, cycle stats.
+- `loops.ts` — inner-loop helpers (cooldown explore).
+- `adaptive-weights.ts` — strategy-yield → per-tier weights.
+- `completeness-audit.ts` — diagnostic counter for skin-coverage gaps.
+- `discord-alerts.ts` — webhook alerts for new all-time-best trade-ups.
+- `phases/` — `housekeeping.ts`, `data-fetch.ts`, `classified-calc.ts`.
+
+## Budget Safety
+CSFloat has 3 independent pools but they **share a 24h lockout** if any reaches 0:
+- Listings: 200 per ~1h rolling window
+- Sales: 500 per ~24h
+- Individual: 50,000 per ~24h (csfloat-checker process)
+
+Safety buffers (`LISTING_SAFETY_BUFFER=5`, `SALE_SAFETY_BUFFER=30`, `INDIVIDUAL_SAFETY_BUFFER=100`) keep us in rolling-replenishment mode and out of the 24h trap. Budget pacing spreads calls across cycles proportional to `cycleDuration / timeUntilReset`.
+
+## Restart
+- **Code changes require hard restart**: `pm2 restart daemon` (the running process holds old code in memory).
+- Fresh restart: `scripts/daemon-fresh.sh` (graceful stop → purge → restart).
+- `SIGUSR2` / `daemon-restart.sh` only useful for config changes that don't require new code.

--- a/server/engine/AGENTS.md
+++ b/server/engine/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/server/engine/CLAUDE.md
+++ b/server/engine/CLAUDE.md
@@ -1,0 +1,62 @@
+# Engine Module Reference
+
+Barrel: `server/engine.ts` re-exports all submodules. External code imports from `./engine.js` only.
+
+## Submodules
+- `types.ts` — interfaces, `EXCLUDED_COLLECTIONS`, `CONDITION_BOUNDS`
+- `utils.ts` — shared helpers: `pick`, `shuffle`, `listingSig`, `parseSig`, `computeChanceToProfit`, `computeBestWorstCase`, `withRetry`, `pickWeightedStrategy`
+- `core.ts` — `calculateOutputFloat`, `calculateOutcomeProbabilities`
+- `data-load.ts` — `getListingsForRarity`, `getOutcomesForCollections`, `loadDiscoveryData`, `buildWeightedPool`, NDJSON serialization helpers
+- `selection.ts` — float-targeted listing selection (dense condition-boundary targets)
+- `store.ts` — `TradeUpStore` (diversity-controlled dedup, profit + chance scoring, `hasSig`)
+- `evaluation.ts` — `evaluateTradeUp` (EV, profit, ROI, chance-to-profit for guns)
+- `knife-evaluation.ts` — `evaluateKnifeTradeUp`, `getKnifeFinishesWithPrices`, `buildKnifeFinishCache`
+- `knife-data.ts` — `CASE_KNIFE_MAP`, finish sets, glove generations, `DOPPLER_PHASES`
+- `pricing.ts` — multi-source price cache (5-min TTL), `lookupOutputPrice`
+- `knn-pricing.ts` — KNN float-precise output pricing for ★ knife/glove (exponential 30-day half-life, 180d max age)
+- `condition-multipliers.ts` — Skinport-derived cross-condition price ratios for ★ skins
+- `curve-classification.ts` — staircase / smooth / flat output curves; drives exploration strategy
+- `observations.ts` — seed / snapshot / prune of `price_observations` (KNN feedstock)
+- `fees.ts` — per-marketplace buyer/seller fees (`MARKETPLACE_FEES`, `effectiveBuyCost`, `effectiveSellProceeds`)
+- `discovery.ts` — `findProfitableTradeUps`, `randomExplore`, `exploreWithBudget`
+- `knife-discovery.ts` — knife/glove variants of the above
+- `staircase.ts` — 2-stage staircase (50 Classified → 5 Covert → 1 Knife)
+- `rarity-tiers.ts` — `RARITY_TIERS`, `getTierById`, `getGunTiers`, `getNewTiers`
+- `db-ops.ts` — barrel re-exporting `db-save`, `db-status`, `db-revive`, `db-stats`
+
+## Pricing Hierarchy
+Output pricing (CSFloat-primary, conservative):
+1. CSFloat sale-based (highest priority)
+2. DMarket listing floor (gap-fill, non-knife commodity, min 2 listings)
+3. Skinport listing floor (gap-fill, min 2 volume)
+4. CSFloat ref prices (fallback)
+5. Cross-condition extrapolation via `condition-multipliers` (last resort, ★ items only)
+6. KNN float-precise (★ knife/glove only)
+
+DMarket is **excluded** from ★ output pricing (thin liquidity, collector outliers).
+
+Input pricing: actual listing price + marketplace buyer fee.
+- CSFloat: 2.8% + $0.30 deposit
+- DMarket: 2.5% buyer fee
+- Skinport: 0% buyer fee
+
+Seller fees deducted from output: CSFloat 2%, DMarket 2%, Skinport 8%.
+
+## Trade-Up Types
+| Type | Inputs | Output | Count |
+|------|--------|--------|-------|
+| covert_knife | Covert guns | Knife / Glove | 5 |
+| classified_covert | Classified | Covert gun | 10 |
+| restricted_classified | Restricted | Classified | 10 |
+| milspec_restricted | Mil-Spec | Restricted | 10 |
+| industrial_milspec | Industrial | Mil-Spec | 10 |
+| consumer_industrial | Consumer | Industrial | 10 |
+| staircase | Classified | 5 Covert → 1 Knife | 50 |
+
+## Key Patterns
+- Chance-to-profit is a first-class metric: trade-ups with >25% chance kept even with negative EV.
+- Discovery-only — every saved trade-up came from exhaustive search over real listings.
+- Merge-save: `mergeTradeUps()` upserts by signature, tracks profit streaks.
+- 30K cap per type for lower-rarity tiers.
+- Discovery skips claimed listings (`AND claimed_by IS NULL`).
+- DMarket name verification: `cleanTitle !== skinName` rejects fuzzy matches before insert.

--- a/server/routes/AGENTS.md
+++ b/server/routes/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/server/routes/CLAUDE.md
+++ b/server/routes/CLAUDE.md
@@ -1,0 +1,56 @@
+# Routes Reference
+
+Express API on port 3001 (proxied by Vite at 5173 in dev). All routers are registered in `server/index.ts`.
+
+## Routers
+- `status.ts`, `status-helpers.ts` — public stats, daemon status, sync meta
+- `trade-ups.ts` — list, detail, filters, output-side joins
+- `data.ts` — collections / skins data feed + crawler-friendly HTML
+- `collections.ts`, `snapshots.ts` — collections page + snapshot viewer
+- `calculator.ts` — manual trade-up calculator
+- `claims.ts` — claim / release / auto-expire
+- `my-trade-ups.ts` — user-claimed history
+- `stripe.ts` — checkout sessions + webhook for Basic / Pro tier
+- `discord.ts` — Discord OAuth + bot webhook endpoints
+- `sitemap.ts` — `sitemap.xml` + `robots.txt`
+- `listing-sniper.ts` — Pro-tier listing alerts
+
+## Auth & Tiers
+Steam OpenID auth. Sessions live in SQLite (`data/sessions.db`).
+
+| Tier | Price | Delay | Claims | Verify | Links |
+|------|-------|-------|--------|--------|-------|
+| Free | $0 | 3 hr | No | No | Yes |
+| Basic | $5/mo | 30 min | 5/day | 10/hr | Yes |
+| Pro | $15/mo | 0 | 10/hr | 20/hr | Yes |
+
+## Claims System
+- `POST /api/trade-ups/:id/claim` — locks listing IDs for 30 min.
+- `DELETE /api/trade-ups/:id/claim` — releases early.
+- Serialized: `pg_advisory_xact_lock(tradeUpId)` plus listing-level `FOR UPDATE`.
+- Auto-expire endpoint uses `FOR UPDATE SKIP LOCKED` to coexist with the daemon.
+- Claimed listings are filtered from discovery (`AND claimed_by IS NULL`).
+- Partial-claim status propagates to all trade-ups sharing a claimed listing.
+- Redis `active_claims` (300s TTL) is the read-side source of truth.
+
+## Verification
+- `POST /api/verify-trade-up/:id` — re-checks input listings via CSFloat / DMarket.
+- Sold / delisted state propagates to ALL trade-ups sharing the listing.
+- Records sale observations (KNN feedstock).
+- Recalculates trade-up cost when prices changed.
+
+## Rate Limiting
+Redis-backed: `checkRateLimit()` / `getRateLimit()` in `server/redis.ts`. Limits returned in API responses for the frontend.
+
+## Caching
+Redis via `cachedRoute()` middleware. Notable TTLs:
+- trade-up list — 30s
+- global-stats — 60s
+- collections — 5 min
+- skin-data — 2 min
+- status — 60s
+
+## API Keys (env)
+- `CSFLOAT_API_KEY`, `DMARKET_PUBLIC_KEY`, `DMARKET_SECRET_KEY`
+- `STRIPE_SECRET_KEY`, `STRIPE_BASIC_PRICE_ID`, `STRIPE_PRO_PRICE_ID`, `STRIPE_WEBHOOK_SECRET`
+- Redis: `localhost:6379` (no auth)

--- a/server/sync/AGENTS.md
+++ b/server/sync/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/server/sync/CLAUDE.md
+++ b/server/sync/CLAUDE.md
@@ -1,0 +1,32 @@
+# Sync Module Reference
+
+Data fetchers. Barrel: `server/sync.ts` re-exports submodules. External code imports from `./sync.js` only.
+
+## Submodules
+- `types.ts` — `CSFloatListing`, `CSFloatSaleEntry`, `SkinCoverageInfo`, `ListingCheckResult`, `CSFLOAT_BASE`, `HIGH_VALUE_COLLECTIONS`
+- `utils.ts` — `getValidConditions`, `isListingTooOld`, `findSkinId`, `saveReferencePrices`
+- `skin-data.ts` — ByMykel API → skin metadata seed
+- `csfloat.ts` — CSFloat listing search (rarity / per-skin / price-range / round-robin / coverage strategies + `verifyTopTradeUpListings`)
+- `sales.ts` — CSFloat `/sales` history (round-robin + per-rarity + knife/glove)
+- `listings.ts` — `purgeStaleListings`, `getSkinsNeedingCoverage`, `checkListingStaleness`
+- `wanted.ts` — theory-guided wanted-list fetch (used after engine flags promising skins)
+- `dmarket.ts` — DMarket fetch + `buyDMarketItem` + `checkDMarketStaleness` + `isDMarketConfigured`
+- `skinport.ts` — Skinport REST price feed
+- `skinport-ws.ts` — Skinport WebSocket (Socket.IO + msgpack); sale observations only, no listings
+- `buff.ts` — Buff.market fetcher (separate process, ~85K Covert listings; main listings table)
+- `doppler-phases.ts` — Doppler-phase mapping helpers
+
+## Source Isolation
+Each market is fetched independently and tagged with `source = 'csfloat' | 'dmarket' | 'skinport' | 'buff'`. The trade-up engine treats sources as substitutable for inputs but applies source-specific rules for output pricing (see engine pricing hierarchy).
+
+## Rate Limits
+- **CSFloat** — 3 independent pools (listings 200/~1h, sales 500/~24h, individual 50K/~24h) sharing a 24h lockout if any hits zero. Daemon paces calls; csfloat-checker owns the individual pool.
+- **DMarket** — 2 RPS for market search (`MIN_INTERVAL_MS = 550ms`), 6 RPS cumulative for other endpoints. Runs as a separate continuous process.
+- **Skinport** — REST is hourly cache; WebSocket is passive (no auth, no quota).
+- **Buff** — separate fetcher (~15 req/min).
+
+## Strategy
+- CSFloat: covert inputs + extraordinary outputs first; round-robin / smart / coverage strategies fill the rest.
+- DMarket: coverage gaps + stale refresh, continuous 2 RPS.
+- Skinport WS: passive sale observations into KNN feedstock — never used to claim listings.
+- DMarket name verification: `cleanTitle !== skinName` rejects fuzzy matches before insert.


### PR DESCRIPTION
## Summary
- Refreshed root `CLAUDE.md` (architecture summary, stack, layout, conventions, imports, TDD, deploy, git) and updated all three nested docs: `server/engine/CLAUDE.md` adds the previously-undocumented `condition-multipliers`, `curve-classification`, `observations`, `utils` submodules; `server/daemon/CLAUDE.md` corrects the stale `WORKER_ROUNDS` pairs (now `knife+classified`, `knife+restricted`, `milspec+industrial`, `consumer`), `MIN_WORKER_TIME = 3 min`, and adds Phase 4b/4c; `server/routes/CLAUDE.md` adds the router inventory.
- Added a new `server/sync/CLAUDE.md` covering fetcher submodules, source isolation, and per-marketplace rate limits.
- Replaced the stale `AGENTS.md` duplicate (root) and added per-module `server/{engine,routes,daemon,sync}/AGENTS.md` as symlinks → `CLAUDE.md`, so the two filenames stay in sync forever.

Note: `CLAUDE.md` files are gitignored in this repo, so the file diff in this PR only contains the AGENTS.md symlinks. The CLAUDE.md content updates were applied directly to the canonical files at `~/trade-up-bot/`.

## Test plan
- [ ] Verify `ls -la AGENTS.md server/{engine,routes,daemon,sync}/AGENTS.md` shows symlinks pointing at `CLAUDE.md`
- [ ] Spot-check the refreshed nested docs against `server/engine/`, `server/routes/`, `server/daemon/`, `server/sync/`
- [ ] Confirm root `CLAUDE.md` is ≤ 200 lines and each nested doc is ≤ 100 lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive project documentation covering system architecture, technology stack, coding conventions, testing methodology, and deployment procedures.
  * Introduced detailed documentation for key server subsystems including daemon discovery, engine pricing hierarchies and trade-up logic, API routing configuration, and market data synchronization strategies.
  * Reorganized documentation references across modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->