### PR TITLE
seo(skins): prune thin skin pages from sitemap + de-boilerplate SSR prose

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -20,7 +20,7 @@ import { discordRouter } from "./routes/discord.js";
 import myTradeUpsRouter from "./routes/my-trade-ups.js";
 import { registerRobotsTxtRoute, sitemapRouter } from "./routes/sitemap.js";
 import { listingSniperRouter } from "./routes/listing-sniper.js";
-import { buildSeoHtml, dedupeHead, isCrawler, injectMetaIntoSpa, escapeHtml, renderTradeUpDetail, renderCollectionsHub, renderTradeUpsHub, deletedTradeUpStatus } from "./seo.js";
+import { buildSeoHtml, dedupeHead, isCrawler, injectMetaIntoSpa, escapeHtml, renderTradeUpDetail, renderCollectionsHub, renderTradeUpsHub, deletedTradeUpStatus, buildSkinResearchParagraphs } from "./seo.js";
 import { toSlug, collectionToSlug } from "../shared/slugs.js";
 import { TRADE_UP_TYPE_LABELS } from "../shared/types.js";
 import { blogPosts } from "../src/data/blog-posts.js";
@@ -839,9 +839,6 @@ registerCanonicalRedirectRoutes(app);
       if (listingCount > 0) {
         naturalParagraph += ` There are currently ${listingCount.toLocaleString()} active listings across CSFloat, DMarket, and Skinport, with prices ranging from $${minPrice} to $${maxPrice}.`;
       }
-      const researchParagraph = `<p>Use this ${e(skinName)} page as a crawler-readable reference for price research, float planning, and collection context before building a trade-up contract. The listing range shows the current low and high market prices available to TradeUpBot, while the float range shows which wear conditions this skin can naturally support. For trade-up inputs, that float range matters because ten input floats are normalized and averaged to determine the output condition. A cheaper listing is not always the best input if its float pushes the contract away from a valuable boundary, so compare price, condition, collection, rarity, and active supply together.</p>`
-        + `<p>${e(skinName)} also connects into the broader CS2 collection graph. Collection links help you inspect sibling skins, identify compatible rarity tiers, and move from a single skin page into collection-level trade-up opportunities. When profitable contracts exist, the trade-up table below summarizes the best examples using this skin as an input, including cost, expected profit, ROI, and chance to profit. These figures are market-sensitive and should be checked against live listings before purchase.</p>`;
-
       let priceTable = "";
       if (condPrices.length > 0) {
         const rows = condPrices.map((p: { condition: string; avg_price_cents: number; median_price_cents: number; min_price_cents: number }) =>
@@ -878,6 +875,23 @@ registerCanonicalRedirectRoutes(app);
       };
       const outputTier = rarityOutputTier[skinMeta.rarity] || "a higher rarity tier";
       const bestProfit = tradeUps.length > 0 ? Math.max(...tradeUps.map((t: { profit_cents: number }) => t.profit_cents)) : 0;
+
+      // Data-driven research prose (replaces the identical two-paragraph boilerplate that
+      // previously rendered on every skin page). Grounded in this skin's own float range,
+      // conditions, rarity tier path, collection, and live trade-up role.
+      const researchParagraph = buildSkinResearchParagraphs({
+        skinName,
+        rarity: skinMeta.rarity,
+        minFloat: skinMeta.min_float,
+        maxFloat: skinMeta.max_float,
+        availableConditions,
+        collectionDisplay: collDisplay || null,
+        // null for terminal items (knives/gloves) so the copy doesn't claim they trade up.
+        outputTier: rarityOutputTier[skinMeta.rarity] ?? null,
+        inputTuCount,
+        outputTuCount,
+        bestProfitCents: bestProfit,
+      });
       const goodInputAnswer = (() => {
         if (inputTuCount === 0) {
           return `${skinName} is not currently used in any profitable trade-up contracts. It is a ${skinMeta.rarity} skin, which trades up into ${outputTier} outputs, but no profitable contracts are available at current market prices.`;

--- a/server/routes/sitemap.ts
+++ b/server/routes/sitemap.ts
@@ -87,9 +87,31 @@ ${urls}
 </urlset>`;
 }
 
-export function buildSkinSitemap(base: string, skins: { name: string; listing_count: number }[], lastmod: string, minListings: number = 10): string {
+export interface SkinSitemapRow {
+  name: string;
+  listing_count: number;
+  /** True when the skin is an input of at least one active, profitable, non-theoretical trade-up. */
+  is_tradeup_input?: boolean;
+  /** True when the skin is produced as an output of such a trade-up. */
+  is_tradeup_output?: boolean;
+  /** Count of price observations in the trailing 30 days (recent market liquidity). */
+  obs30?: number;
+}
+
+/**
+ * A skin page earns a sitemap slot (and index-worthiness) only when it carries content a
+ * generic price-catalog page would not: it participates in the trade-up graph, or it has
+ * substantive recent price history. Listing count alone is a near-useless signal here —
+ * nearly every skin has 100+ listings — so it is only a spam floor, not the bar.
+ */
+export function isSkinIndexworthy(row: SkinSitemapRow, minListings = 10, minObs = 20): boolean {
+  if ((row.listing_count ?? 0) < minListings) return false;
+  return Boolean(row.is_tradeup_input) || Boolean(row.is_tradeup_output) || (row.obs30 ?? 0) >= minObs;
+}
+
+export function buildSkinSitemap(base: string, skins: SkinSitemapRow[], lastmod: string, minListings = 10, minObs = 20): string {
   const urls = skins
-    .filter(s => s.listing_count >= minListings)
+    .filter(s => isSkinIndexworthy(s, minListings, minObs))
     .map(s =>
       `  <url><loc>${base}/skins/${toSlug(s.name)}</loc><lastmod>${lastmod}</lastmod><changefreq>daily</changefreq><priority>0.6</priority></url>`
     ).join("\n");
@@ -167,11 +189,35 @@ export function sitemapRouter(pool: pg.Pool): Router {
         res.send(cached);
         return;
       }
+      // Signals per skin: listing count (spam floor), recent price-observation volume,
+      // and whether the skin participates in the profitable trade-up graph. Only skins
+      // that clear the quality bar (see isSkinIndexworthy) are advertised — a generic
+      // price-lookup page adds no unique value on a young site and dilutes crawl budget.
       const { rows } = await pool.query(`
-        SELECT s.name, COUNT(l.id)::int as listing_count
-        FROM skins s LEFT JOIN listings l ON s.id = l.skin_id
+        SELECT s.name,
+               COUNT(l.id)::int AS listing_count,
+               COALESCE(po.obs30, 0)::int AS obs30,
+               EXISTS (
+                 SELECT 1 FROM trade_up_inputs ti
+                 JOIN trade_ups t ON ti.trade_up_id = t.id
+                 WHERE ti.skin_name = s.name
+                   AND t.listing_status = 'active' AND t.is_theoretical = false AND t.profit_cents > 0
+               ) AS is_tradeup_input,
+               EXISTS (
+                 SELECT 1 FROM trade_ups t
+                 WHERE t.output_skin_names @> ARRAY[s.name]::text[]
+                   AND t.listing_status = 'active' AND t.is_theoretical = false AND t.profit_cents > 0
+               ) AS is_tradeup_output
+        FROM skins s
+        LEFT JOIN listings l ON s.id = l.skin_id
+        LEFT JOIN (
+          SELECT skin_name, COUNT(*) AS obs30
+          FROM price_observations
+          WHERE observed_at > NOW() - INTERVAL '30 days'
+          GROUP BY skin_name
+        ) po ON po.skin_name = s.name
         WHERE s.stattrak = false
-        GROUP BY s.name
+        GROUP BY s.name, po.obs30
         ORDER BY s.name
       `);
       const xml = buildSkinSitemap(BASE, rows, lastmod);

--- a/server/seo.ts
+++ b/server/seo.ts
@@ -23,6 +23,75 @@ export function escapeHtml(str: string): string {
     .replace(/"/g, "&quot;");
 }
 
+export interface SkinResearchInput {
+  skinName: string;
+  rarity: string;
+  minFloat: number;
+  maxFloat: number;
+  /** Human-ordered condition names this skin can appear in (Factory New → Battle-Scarred). */
+  availableConditions: string[];
+  /** Cleaned collection name (no "The"/"Collection" affixes), or null if uncollected. */
+  collectionDisplay: string | null;
+  /** The rarity tier this skin trades up INTO (e.g. Classified → Covert), or null for
+   *  terminal items (knives/gloves) that are a trade-up result and never an input. */
+  outputTier: string | null;
+  inputTuCount: number;
+  outputTuCount: number;
+  bestProfitCents: number;
+}
+
+/**
+ * Two data-driven research paragraphs for a /skins/:slug crawler page. Every clause is
+ * grounded in this skin's own float range, conditions, rarity, collection, and live
+ * trade-up role, so the prose varies materially page-to-page instead of the identical
+ * boilerplate that made ~900 skin pages read as near-duplicates to Googlebot.
+ */
+export function buildSkinResearchParagraphs(i: SkinResearchInput): string {
+  const e = escapeHtml;
+  const name = e(i.skinName);
+  const rarity = e(i.rarity);
+  const lo = i.minFloat.toFixed(2);
+  const hi = i.maxFloat.toFixed(2);
+
+  const conds = i.availableConditions;
+  const condList = conds.length <= 1
+    ? (conds[0] ?? "a single")
+    : `${conds.slice(0, -1).join(", ")} and ${conds[conds.length - 1]}`;
+  const worst = conds[conds.length - 1] ?? "a heavier wear";
+
+  const para1 = conds.length <= 1
+    ? `<p>${name} carries a float range of ${lo}–${hi}, so it only appears in ${e(condList)} condition. `
+      + `In a trade-up, ten input floats are averaged and normalized to the output's own range, so ${name}'s narrow float band keeps the resulting output condition tightly constrained. `
+      + `That predictability is exactly why float, not just the sticker price, matters when using ${name} as an input.</p>`
+    : `<p>${name} carries a float range of ${lo}–${hi}, so it can appear in ${e(condList)} conditions. `
+      + `In a trade-up, ten input floats are averaged and normalized to the output's own range: an input near ${lo} contributes the cleanest float it can, while one near ${hi} drags the average toward ${e(worst)}. `
+      + `That makes float, not just the sticker price, a deciding factor when using ${name} as an input.</p>`;
+
+  const collPhrase = i.collectionDisplay ? ` from the ${e(i.collectionDisplay)} collection` : "";
+  const collDraw = i.collectionDisplay ? ` drawn from the ${e(i.collectionDisplay)} collection` : "";
+  let para2 = `<p>${name} is a ${rarity} skin${collPhrase}. `;
+  // Terminal items (knives/gloves) have no output tier — they are a trade-up result, not an
+  // input — so we must not claim they "trade up into" anything.
+  para2 += i.outputTier
+    ? `Ten ${rarity} inputs${collDraw} trade up into a ${e(i.outputTier)} output, so ${name} sits one tier below the results it helps produce.`
+    : `As a top-tier item it is a trade-up result rather than an input, so it appears as the payoff of a contract rather than a feeder into one.`;
+  if (i.inputTuCount > 0) {
+    para2 += ` At current market prices it appears as an input in ${i.inputTuCount} profitable contract${i.inputTuCount !== 1 ? "s" : ""}`;
+    para2 += i.bestProfitCents > 0 ? `, the best worth $${(i.bestProfitCents / 100).toFixed(2)} in modeled profit.` : ".";
+  }
+  if (i.outputTuCount > 0) {
+    para2 += ` ${i.outputTuCount} profitable contract${i.outputTuCount !== 1 ? "s" : ""} can produce ${name} as an output.`;
+  }
+  if (i.inputTuCount === 0 && i.outputTuCount === 0) {
+    para2 += i.collectionDisplay
+      ? ` No profitable contracts use ${name} at current market prices, but its collection and float profile still shape which contracts become viable as prices move.`
+      : ` No profitable contracts use ${name} at current market prices, but its float profile still shapes which contracts become viable as prices move.`;
+  }
+  para2 += `</p>`;
+
+  return para1 + para2;
+}
+
 export function dedupeHead(html: string): string {
   const headMatch = html.match(/<head[^>]*>[\s\S]*?<\/head>/i);
   if (!headMatch || headMatch.index === undefined) return html;

--- a/tests/unit/internal-cross-linking.test.ts
+++ b/tests/unit/internal-cross-linking.test.ts
@@ -69,7 +69,7 @@ describe("internal cross-linking SEO guarantees", () => {
     const base = "https://tradeupbot.app";
     const lastmod = "2026-05-13";
     const collections = Array.from({ length: 12 }, (_, index) => ({ name: `Test Collection ${index + 1}` }));
-    const skins = Array.from({ length: 60 }, (_, index) => ({ name: `AK-47 | Test Skin ${index + 1}`, listing_count: 10 }));
+    const skins = Array.from({ length: 60 }, (_, index) => ({ name: `AK-47 | Test Skin ${index + 1}`, listing_count: 10, obs30: 30 }));
 
     const index = buildSitemapIndex(base, lastmod);
     expect(index).toContain(`${base}/sitemap-static.xml`);

--- a/tests/unit/sitemap-consistency.test.ts
+++ b/tests/unit/sitemap-consistency.test.ts
@@ -53,7 +53,7 @@ describe("robots.txt and sitemap consistency", () => {
       buildStaticSitemap(BASE, LASTMOD),
       buildCollectionSitemap(BASE, [{ name: "The Dreams & Nightmares Collection" }], LASTMOD),
       buildCollectionTradeUpSitemap(BASE, [{ name: "The Fracture Collection" }], LASTMOD),
-      buildSkinSitemap(BASE, [{ name: "AK-47 | Redline", listing_count: 10 }], LASTMOD),
+      buildSkinSitemap(BASE, [{ name: "AK-47 | Redline", listing_count: 10, is_tradeup_input: true }], LASTMOD),
     ];
     const locs = sitemaps.flatMap(extractLocs);
 
@@ -68,7 +68,7 @@ describe("robots.txt and sitemap consistency", () => {
 
   it("skin sitemap excludes low-listing noindex skin pages", () => {
     const xml = buildSkinSitemap(BASE, [
-      { name: "AK-47 | Redline", listing_count: 10 },
+      { name: "AK-47 | Redline", listing_count: 10, is_tradeup_input: true },
       { name: "Glock-18 | Low Listings", listing_count: 9 },
     ], LASTMOD);
     const locs = extractLocs(xml);
@@ -82,7 +82,7 @@ describe("robots.txt and sitemap consistency", () => {
       buildStaticSitemap(BASE, LASTMOD),
       buildCollectionSitemap(BASE, [{ name: "The Dreams & Nightmares Collection" }], LASTMOD),
       buildCollectionTradeUpSitemap(BASE, [{ name: "The Fracture Collection" }], LASTMOD),
-      buildSkinSitemap(BASE, [{ name: "AK-47 | Redline", listing_count: 10 }], LASTMOD),
+      buildSkinSitemap(BASE, [{ name: "AK-47 | Redline", listing_count: 10, is_tradeup_input: true }], LASTMOD),
     ];
 
     for (const xml of sitemaps) {

--- a/tests/unit/sitemap-thresholds.test.ts
+++ b/tests/unit/sitemap-thresholds.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildSkinSitemap } from "../../server/routes/sitemap.js";
+import { buildSkinSitemap, isSkinIndexworthy } from "../../server/routes/sitemap.js";
 
 const BASE = "https://tradeupbot.app";
 const LASTMOD = "2026-06-10";
@@ -8,34 +8,62 @@ function extractLocs(xml: string): string[] {
   return Array.from(xml.matchAll(/<loc>([^<]+)<\/loc>/g)).map(m => m[1]);
 }
 
-describe("buildSkinSitemap hysteresis threshold", () => {
+describe("isSkinIndexworthy quality bar", () => {
+  it("requires the listing floor regardless of other signals", () => {
+    // Below the listing floor, even a trade-up input is not index-worthy.
+    expect(isSkinIndexworthy({ name: "x", listing_count: 4, is_tradeup_input: true })).toBe(false);
+  });
+
+  it("admits trade-up inputs above the listing floor", () => {
+    expect(isSkinIndexworthy({ name: "x", listing_count: 10, is_tradeup_input: true })).toBe(true);
+  });
+
+  it("admits trade-up outputs above the listing floor", () => {
+    expect(isSkinIndexworthy({ name: "x", listing_count: 12, is_tradeup_output: true })).toBe(true);
+  });
+
+  it("admits skins with substantive recent price history (obs30 >= 20)", () => {
+    expect(isSkinIndexworthy({ name: "x", listing_count: 50, obs30: 20 })).toBe(true);
+  });
+
+  it("EXCLUDES commodity pages: plenty of listings but no trade-up role and thin price history", () => {
+    // This is the ~1,240-page thin bucket we are pruning: lots of listings (a useless
+    // signal — nearly every skin has >100), but no unique trade-up value and little history.
+    expect(isSkinIndexworthy({ name: "x", listing_count: 300, obs30: 5 })).toBe(false);
+    expect(isSkinIndexworthy({ name: "x", listing_count: 300 })).toBe(false);
+  });
+
+  it("honours caller-supplied thresholds", () => {
+    expect(isSkinIndexworthy({ name: "x", listing_count: 30, obs30: 15 }, 10, 10)).toBe(true);
+    expect(isSkinIndexworthy({ name: "x", listing_count: 30, obs30: 15 }, 10, 20)).toBe(false);
+  });
+});
+
+describe("buildSkinSitemap quality-bar pruning", () => {
   const skins = [
-    { name: "AK-47 | Count 4", listing_count: 4 },
-    { name: "AK-47 | Count 7", listing_count: 7 },
-    { name: "AK-47 | Count 10", listing_count: 10 },
-    { name: "AK-47 | Count 12", listing_count: 12 },
+    { name: "AK-47 | Input", listing_count: 12, is_tradeup_input: true, obs30: 0 },
+    { name: "AK-47 | Output", listing_count: 12, is_tradeup_output: true, obs30: 0 },
+    { name: "AK-47 | Liquid", listing_count: 80, obs30: 40 },
+    { name: "AK-47 | Thin", listing_count: 300, obs30: 3 },
+    { name: "AK-47 | BelowFloor", listing_count: 4, is_tradeup_input: true, obs30: 99 },
   ];
 
-  it("default threshold is 10: excludes skins with listing_count < 10", () => {
-    const xml = buildSkinSitemap(BASE, skins, LASTMOD);
-    const locs = extractLocs(xml);
-    // Counts 4 and 7 are below 10 — must be excluded
-    expect(locs).not.toContain(`${BASE}/skins/ak-47-count-4`);
-    expect(locs).not.toContain(`${BASE}/skins/ak-47-count-7`);
+  it("includes trade-up-linked and liquid skins", () => {
+    const locs = extractLocs(buildSkinSitemap(BASE, skins, LASTMOD));
+    expect(locs).toContain(`${BASE}/skins/ak-47-input`);
+    expect(locs).toContain(`${BASE}/skins/ak-47-output`);
+    expect(locs).toContain(`${BASE}/skins/ak-47-liquid`);
   });
 
-  it("default threshold is 10: includes skins with listing_count >= 10", () => {
-    const xml = buildSkinSitemap(BASE, skins, LASTMOD);
-    const locs = extractLocs(xml);
-    // Counts 10 and 12 meet the threshold — must be included
-    expect(locs).toContain(`${BASE}/skins/ak-47-count-10`);
-    expect(locs).toContain(`${BASE}/skins/ak-47-count-12`);
+  it("excludes thin commodity pages and sub-floor skins", () => {
+    const locs = extractLocs(buildSkinSitemap(BASE, skins, LASTMOD));
+    expect(locs).not.toContain(`${BASE}/skins/ak-47-thin`);
+    expect(locs).not.toContain(`${BASE}/skins/ak-47-belowfloor`);
   });
 
-  it("caller can override the threshold (floor can be raised further)", () => {
-    const xml = buildSkinSitemap(BASE, skins, LASTMOD, 12);
-    const locs = extractLocs(xml);
-    expect(locs).not.toContain(`${BASE}/skins/ak-47-count-10`);
-    expect(locs).toContain(`${BASE}/skins/ak-47-count-12`);
+  it("treats a missing obs30 as zero history (backward compatible rows are pruned unless linked)", () => {
+    const rows = [{ name: "AK-47 | NoSignals", listing_count: 500 }];
+    const locs = extractLocs(buildSkinSitemap(BASE, rows, LASTMOD));
+    expect(locs).not.toContain(`${BASE}/skins/ak-47-nosignals`);
   });
 });

--- a/tests/unit/sitemap.test.ts
+++ b/tests/unit/sitemap.test.ts
@@ -58,11 +58,11 @@ describe("buildCollectionSitemap", () => {
 });
 
 describe("buildSkinSitemap", () => {
-  it("generates URLs for skins using slugs", () => {
+  it("generates URLs for index-worthy skins using slugs", () => {
     const skins = [
-      { name: "AK-47 | Redline", listing_count: 10 },
-      { name: "M4A4 | Howl", listing_count: 20 },
-      { name: "Glock-18 | Fade", listing_count: 2 },
+      { name: "AK-47 | Redline", listing_count: 10, is_tradeup_input: true },
+      { name: "M4A4 | Howl", listing_count: 20, obs30: 50 },
+      { name: "Glock-18 | Fade", listing_count: 2, is_tradeup_output: true }, // sub-floor
     ];
     const xml = buildSkinSitemap("https://tradeupbot.app", skins, "2026-03-24", 5);
     expect(xml).toContain("tradeupbot.app/skins/ak-47-redline");

--- a/tests/unit/skin-research-copy.test.ts
+++ b/tests/unit/skin-research-copy.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { buildSkinResearchParagraphs } from "../../server/seo.js";
+
+const AK: Parameters<typeof buildSkinResearchParagraphs>[0] = {
+  skinName: "AK-47 | Redline",
+  rarity: "Classified",
+  minFloat: 0.1,
+  maxFloat: 0.7,
+  availableConditions: ["Minimal Wear", "Field-Tested", "Well-Worn", "Battle-Scarred"],
+  collectionDisplay: "Phoenix",
+  outputTier: "Covert",
+  inputTuCount: 3,
+  outputTuCount: 0,
+  bestProfitCents: 1234,
+};
+
+const GLOVE: Parameters<typeof buildSkinResearchParagraphs>[0] = {
+  skinName: "Desert Eagle | Blaze",
+  rarity: "Restricted",
+  minFloat: 0.0,
+  maxFloat: 0.08,
+  availableConditions: ["Factory New", "Minimal Wear"],
+  collectionDisplay: null,
+  outputTier: "Classified",
+  inputTuCount: 0,
+  outputTuCount: 0,
+  bestProfitCents: 0,
+};
+
+describe("buildSkinResearchParagraphs", () => {
+  it("returns exactly two paragraphs", () => {
+    const html = buildSkinResearchParagraphs(AK);
+    expect((html.match(/<p>/g) ?? []).length).toBe(2);
+    expect((html.match(/<\/p>/g) ?? []).length).toBe(2);
+  });
+
+  it("weaves in the skin's real float numbers, rarity, and output tier", () => {
+    const html = buildSkinResearchParagraphs(AK);
+    expect(html).toContain("0.10");
+    expect(html).toContain("0.70");
+    expect(html).toContain("Classified");
+    expect(html).toContain("Covert");
+  });
+
+  it("HTML-escapes interpolated names (ampersand in collection)", () => {
+    const html = buildSkinResearchParagraphs({ ...AK, collectionDisplay: "Dreams & Nightmares" });
+    expect(html).toContain("Dreams &amp; Nightmares");
+    expect(html).not.toContain("Dreams & Nightmares");
+  });
+
+  it("mentions the collection when present and omits it when absent", () => {
+    expect(buildSkinResearchParagraphs(AK)).toContain("Phoenix");
+    const noColl = buildSkinResearchParagraphs(GLOVE);
+    expect(noColl).not.toContain("collection undefined");
+    expect(noColl).not.toContain("null");
+  });
+
+  it("surfaces the profitable-contract count and best profit when the skin is an input", () => {
+    const html = buildSkinResearchParagraphs(AK);
+    expect(html).toContain("3 profitable");
+    expect(html).toContain("$12.34");
+  });
+
+  it("states plainly when no profitable contracts exist, without overclaiming", () => {
+    const html = buildSkinResearchParagraphs(GLOVE);
+    expect(html.toLowerCase()).toContain("no profitable");
+    // Never promise exact/guaranteed sale outcomes (codex overclaim guard).
+    expect(html.toLowerCase()).not.toContain("guarantee");
+    expect(html.toLowerCase()).not.toContain("exact output");
+  });
+
+  it("produces materially different prose per skin (de-boilerplate)", () => {
+    const a = buildSkinResearchParagraphs(AK);
+    const b = buildSkinResearchParagraphs(GLOVE);
+    expect(a).not.toEqual(b);
+    // The distinctive, skin-specific tokens must not leak across pages.
+    expect(a).not.toContain("Desert Eagle");
+    expect(b).not.toContain("Redline");
+  });
+
+  it("does NOT claim terminal items (knives/gloves, null outputTier) trade up", () => {
+    const glove = {
+      skinName: "Sport Gloves | Pandora's Box",
+      rarity: "Extraordinary",
+      minFloat: 0.06,
+      maxFloat: 0.8,
+      availableConditions: ["Minimal Wear", "Field-Tested", "Well-Worn", "Battle-Scarred"],
+      collectionDisplay: null,
+      outputTier: null,
+      inputTuCount: 0,
+      outputTuCount: 4,
+      bestProfitCents: 0,
+    };
+    const html = buildSkinResearchParagraphs(glove);
+    expect(html).not.toContain("trade up into");
+    expect(html).not.toContain("sits one tier below");
+    expect(html).toContain("trade-up result");
+    expect(html).toContain("4 profitable"); // still surfaces its output role
+  });
+
+  it("uses singular grammar for float-only note when there is no collection", () => {
+    const html = buildSkinResearchParagraphs(GLOVE); // collectionDisplay: null, no contracts
+    expect(html).toContain("its float profile still shapes");
+    expect(html).not.toContain("collection and float profile");
+  });
+
+  it("handles a single-condition skin without dangling grammar", () => {
+    const single = { ...GLOVE, availableConditions: ["Factory New"] };
+    const html = buildSkinResearchParagraphs(single);
+    expect(html).toContain("Factory New");
+    expect(html).not.toContain(", condition");
+    expect(html).not.toContain(" and .");
+  });
+});


### PR DESCRIPTION
## Why
GSC (2026-07-15 export) shows the skin-page corpus is the site's SEO drag:
- **~897** skin pages "Crawled – currently not indexed"
- **~211** pages deindexed on 2026-06-30 (indexed 1,985 → 1,774)
- site-average position drifting 15 → 40 (a mix/dilution effect; core pages are stable)

Root cause: **1,920 skin URLs** advertised in `sitemap-skins.xml`, most rendering near-identical boilerplate and competing in a commodity space (skin price lookup) where Google already trusts Steam/CSFloat.

Diagnosis writeup and data: listing count is a useless quality signal (1,817 skins have >100 listings); the site's real differentiator is the **trade-up graph** (29 inputs + 118 outputs) plus substantive price history.

## What
**1. Sitemap quality bar** (`server/routes/sitemap.ts`)
New `isSkinIndexworthy` predicate: `listings >= 10` (spam floor) **AND** (`trade-up input` OR `trade-up output` OR `>= 20 price obs / 30d`). Route query surfaces the signals.
- Prod effect: **sitemap-skins 1,920 → ~682 URLs** (validated against prod DB).
- **Soft prune** — pages are NOT `noindex`, so the GSC *indexed* count stays stable. This concentrates crawl budget on pages that can actually earn indexing. Reversible; escalate to noindex only if the tail keeps dragging.

**2. De-boilerplate skin SSR prose** (`server/seo.ts` `buildSkinResearchParagraphs`, wired in `server/index.ts`)
The two identical ~150-word "research" paragraphs that rendered word-for-word on all 1,920 pages are replaced with data-driven prose grounded in each skin's own float range, conditions, rarity tier path, collection, and live trade-up role. Terminal items (knives/gloves) are correctly described as trade-up *results*, not inputs.

## Notes
- The `>=10` listing floor is applied to trade-up-linked skins too — deliberate, and a no-op on current data (0 trade-up-linked skins have <10 listings).
- Opened as a PR (not pushed to main) because another agent is working in the same checkout on backend perf. Isolated in a git worktree.
- Adversarially reviewed with codex (gpt-5.5); the two real findings (knife/glove false-claim, null-collection grammar) are fixed; the "5-input contract" finding was a hallucination (all CS2 trade-ups are 10-input).

## Verification
- `npm run test:unit` → **760 passed**; `tsc --noEmit` clean
- Exact new sitemap query run against prod: 682 qualifying, no error
- Sampled generated prose for input/output/terminal/no-collection skins — reads naturally, materially varied per skin

## Merge → deploy
Merging to `main` auto-deploys the VPS via CI. Post-merge the sitemap cache (`sitemap_skins_xml`, 1h TTL) and per-skin caches (`seo_skin:*`, 1h TTL) roll over within an hour; can flush Redis to apply immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **SEO Improvements**
  * Skin pages now display richer, dynamically generated research content, including float ranges, conditions, rarity, collections, and trade-up information.
  * Skin research copy now adapts to each skin’s available data and trade-up role.

* **Bug Fixes**
  * Skin sitemaps now prioritize active, relevant pages using listing activity, recent price observations, and profitable trade-up participation.
  * Low-quality or inactive skin pages are excluded from sitemap listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->