### PR TITLE
Frontend rework: filter UX, stale-leak coherence guard, copy de-slop, latency fixes

### DIFF
--- a/server/routes/trade-ups.ts
+++ b/server/routes/trade-ups.ts
@@ -3,7 +3,7 @@ import pg from "pg";
 import { priceCache, priceSources, cascadeTradeUpStatuses, CONDITION_BOUNDS } from "../engine.js";
 import { fetchAllDMarketListings, isDMarketConfigured } from "../sync.js";
 import { getTierConfig, type User } from "../auth.js";
-import { cachedRoute, getRateLimit } from "../redis.js";
+import { cachedRoute, getRateLimit, cacheInvalidatePrefix } from "../redis.js";
 import { getActiveClaims } from "./claims.js";
 import type { TradeUp, TradeUpInput, TradeUpOutcome, InputSummary } from "../../shared/types.js";
 
@@ -365,7 +365,7 @@ export function tradeUpsRouter(pool: pg.Pool): Router {
     // Data query always runs (fast: index scan + LIMIT).
     // Correlated subqueries for real_input_count / missing_count have been moved to a
     // single batched query after the page rows resolve (see batchLoadInputCounts).
-    const dataPromise = pool.query(
+    const dataSql =
       `SELECT t.id, t.type, t.total_cost_cents, t.expected_value_cents, t.profit_cents,
               t.roi_percentage, t.created_at, t.is_theoretical, t.listing_status,
               t.peak_profit_cents, t.profit_streak, t.preserved_at, t.previous_inputs,
@@ -374,9 +374,9 @@ export function tradeUpsRouter(pool: pg.Pool): Router {
               0 as outcome_count
        FROM trade_ups t ${collectionJoin} ${where}
        ORDER BY ${sortCol} ${sortOrder} NULLS LAST, t.id DESC
-       LIMIT $${limitParam} OFFSET $${offsetParam}`,
-      [...params, perPage, offset]
-    );
+       LIMIT $${limitParam} OFFSET $${offsetParam}`;
+    const dataParams = [...params, perPage, offset];
+    const dataPromise = pool.query(dataSql, dataParams);
 
     let total: number;
     let totalProfitable: number;
@@ -415,12 +415,65 @@ export function tradeUpsRouter(pool: pg.Pool): Router {
       totalProfitable = 0; // Not available for filtered queries (arbitrary subset would be meaningless)
     }
 
-    const rows = (await dataPromise).rows;
+    let rows = (await dataPromise).rows;
 
     // Batch-load real_input_count and missing_count for all page rows in one query.
     // This replaces the two correlated subqueries that were inlined in the SELECT above.
+    let inputCountsById = await batchLoadInputCounts(pool, rows.map((r: { id: number }) => r.id));
+
+    // Coherence guard: the WHERE filtered on the listing_status COLUMN, but canonical
+    // status is recomputed from live listings (batchLoadInputCounts). A listing deleted
+    // without cascadeTradeUpStatuses running (race, crashed fetcher) leaves the column
+    // 'active' — the row passes the WHERE, then renders partial/stale in the default
+    // view. Heal the column (the UPDATE revalidates missing counts in the same
+    // statement, so a listing reinserted since the batch count can't be mis-marked),
+    // invalidate cached pages that may still hold the leaked rows, and requery once so
+    // the page has no holes. Rows claimed by the requesting user stay visible — the
+    // claimer must see their inputs went missing.
+    if (!includeStale && my_claims !== "true") {
+      const leakedIds = rows
+        .filter((r: { id: number }) => {
+          const c = inputCountsById.get(r.id);
+          return c !== undefined && c.missing_count > 0 && !claimedByMe.has(r.id);
+        })
+        .map((r: { id: number }) => r.id);
+      if (leakedIds.length > 0) {
+        const { rows: healed } = await pool.query(
+          `WITH live AS (
+             SELECT tui.trade_up_id,
+                    COUNT(*) FILTER (WHERE tui.listing_id NOT LIKE 'theor%')::int AS real_inputs,
+                    COUNT(*) FILTER (WHERE tui.listing_id NOT LIKE 'theor%' AND l.id IS NULL)::int AS missing
+             FROM trade_up_inputs tui
+             LEFT JOIN listings l ON tui.listing_id = l.id
+             WHERE tui.trade_up_id = ANY($1::int[])
+             GROUP BY tui.trade_up_id
+           )
+           UPDATE trade_ups t SET
+             listing_status = CASE WHEN live.missing >= live.real_inputs THEN 'stale' ELSE 'partial' END,
+             preserved_at = COALESCE(t.preserved_at, NOW())
+           FROM live
+           WHERE t.id = live.trade_up_id
+             AND t.listing_status = 'active'
+             AND live.missing > 0
+             AND NOT EXISTS (
+               SELECT 1 FROM trade_up_claims tc
+               WHERE tc.trade_up_id = t.id AND tc.released_at IS NULL AND tc.expires_at > NOW()
+             )
+           RETURNING t.id`,
+          [leakedIds]
+        );
+        if (healed.length > 0) {
+          await cacheInvalidatePrefix("tu:");
+          // Healed rows are excluded by the WHERE now — refill the page slots.
+          rows = (await pool.query(dataSql, dataParams)).rows;
+          inputCountsById = await batchLoadInputCounts(pool, rows.map((r: { id: number }) => r.id));
+          // The count queries ran against the pre-heal set.
+          total = Math.max(0, total - healed.length);
+        }
+      }
+    }
+
     const tuIds = rows.map((r: { id: number }) => r.id);
-    const inputCountsById = await batchLoadInputCounts(pool, tuIds);
 
     // Batch-load lightweight input summaries (skin_name, condition, collection_name only).
     // Full inputs are loaded on-demand when expanding a row via /api/trade-up/:id/inputs.
@@ -458,9 +511,9 @@ export function tradeUpsRouter(pool: pg.Pool): Router {
       }
     }
 
-    // Status is maintained by cascadeTradeUpStatuses (on listing delete/claim).
-    // No read-time auto-correct needed — trust listing_status column.
-    // Missing input counts computed on-demand when user expands a row (inputs endpoint).
+    // Canonical status may still disagree with the column for rows the heal skipped
+    // (claim-guarded) or for deletions racing the requery — those residuals are dropped
+    // below rather than healed again (bounded to one requery per request).
 
     const tradeUps: TradeUp[] = rows.map((row: any) => {
       const summary = summaryByTuId.get(row.id) ?? { skins: [], collections: [], input_count: 0 };
@@ -503,35 +556,15 @@ export function tradeUpsRouter(pool: pg.Pool): Router {
       };
     });
 
-    // Coherence guard: the WHERE filtered on the listing_status COLUMN, but canonical
-    // status was just recomputed from live listings (batchLoadInputCounts). A listing
-    // deleted without cascadeTradeUpStatuses running (race, crashed fetcher) leaves the
-    // column 'active' — the row passes the WHERE, then renders partial/stale in the
-    // default view. Drop leaked rows from the page and write the corrected status back
-    // (self-healing: the next uncached query excludes them in SQL). Rows claimed by the
-    // requesting user stay visible — the claimer must see their inputs went missing.
-    const leakedIds = new Set<number>();
+    const residualLeaks = new Set<number>();
     if (!includeStale && my_claims !== "true") {
-      const leaked = tradeUps.filter(tu => tu.listing_status !== "active" && !tu.claimed_by_me);
-      if (leaked.length > 0) {
-        for (const tu of leaked) leakedIds.add(tu.id);
-        const staleIds = leaked.filter(tu => tu.listing_status === "stale").map(tu => tu.id);
-        await pool.query(
-          `UPDATE trade_ups SET
-             listing_status = CASE WHEN id = ANY($2::int[]) THEN 'stale' ELSE 'partial' END,
-             preserved_at = COALESCE(preserved_at, NOW())
-           WHERE id = ANY($1::int[]) AND listing_status = 'active'
-             AND NOT EXISTS (
-               SELECT 1 FROM trade_up_claims tc
-               WHERE tc.trade_up_id = trade_ups.id AND tc.released_at IS NULL AND tc.expires_at > NOW()
-             )`,
-          [[...leakedIds], staleIds]
-        );
+      for (const tu of tradeUps) {
+        if (tu.listing_status !== "active" && !tu.claimed_by_me) residualLeaks.add(tu.id);
       }
     }
 
     // Hide trade-ups claimed by other users (they shouldn't see claimed opportunities)
-    const filteredTradeUps = tradeUps.filter(tu => !tu.claimed_by_other && !leakedIds.has(tu.id));
+    const filteredTradeUps = tradeUps.filter(tu => !tu.claimed_by_other && !residualLeaks.has(tu.id));
     const removedOnPage = tradeUps.length - filteredTradeUps.length;
 
     const result = {

--- a/server/routes/trade-ups.ts
+++ b/server/routes/trade-ups.ts
@@ -503,8 +503,35 @@ export function tradeUpsRouter(pool: pg.Pool): Router {
       };
     });
 
+    // Coherence guard: the WHERE filtered on the listing_status COLUMN, but canonical
+    // status was just recomputed from live listings (batchLoadInputCounts). A listing
+    // deleted without cascadeTradeUpStatuses running (race, crashed fetcher) leaves the
+    // column 'active' — the row passes the WHERE, then renders partial/stale in the
+    // default view. Drop leaked rows from the page and write the corrected status back
+    // (self-healing: the next uncached query excludes them in SQL). Rows claimed by the
+    // requesting user stay visible — the claimer must see their inputs went missing.
+    const leakedIds = new Set<number>();
+    if (!includeStale && my_claims !== "true") {
+      const leaked = tradeUps.filter(tu => tu.listing_status !== "active" && !tu.claimed_by_me);
+      if (leaked.length > 0) {
+        for (const tu of leaked) leakedIds.add(tu.id);
+        const staleIds = leaked.filter(tu => tu.listing_status === "stale").map(tu => tu.id);
+        await pool.query(
+          `UPDATE trade_ups SET
+             listing_status = CASE WHEN id = ANY($2::int[]) THEN 'stale' ELSE 'partial' END,
+             preserved_at = COALESCE(preserved_at, NOW())
+           WHERE id = ANY($1::int[]) AND listing_status = 'active'
+             AND NOT EXISTS (
+               SELECT 1 FROM trade_up_claims tc
+               WHERE tc.trade_up_id = trade_ups.id AND tc.released_at IS NULL AND tc.expires_at > NOW()
+             )`,
+          [[...leakedIds], staleIds]
+        );
+      }
+    }
+
     // Hide trade-ups claimed by other users (they shouldn't see claimed opportunities)
-    const filteredTradeUps = tradeUps.filter(tu => !tu.claimed_by_other);
+    const filteredTradeUps = tradeUps.filter(tu => !tu.claimed_by_other && !leakedIds.has(tu.id));
     const removedOnPage = tradeUps.length - filteredTradeUps.length;
 
     const result = {

--- a/src/components/CollectionViewer.tsx
+++ b/src/components/CollectionViewer.tsx
@@ -43,16 +43,19 @@ export function CollectionViewer({ collectionName, onBack, onNavigateCollection 
   const [filters, setFilters] = useState<Filters>({ ...EMPTY_FILTERS });
 
   useEffect(() => {
+    const ctrl = new AbortController();
     setLoading(true);
-    fetch(`/api/collection/${collectionToSlug(collectionName)}`)
+    fetch(`/api/collection/${collectionToSlug(collectionName)}`, { signal: ctrl.signal })
       .then(r => r.json())
       .then(data => setKnifePool(data.knifePool || null))
       .catch(() => {})
-      .finally(() => setLoading(false));
+      .finally(() => { if (!ctrl.signal.aborted) setLoading(false); });
+    return () => ctrl.abort();
   }, [collectionName]);
 
   // Fetch trade-ups with collection filter + type + filters
   useEffect(() => {
+    const ctrl = new AbortController();
     setTradeUpsLoading(true);
     const params = filtersToParams(filters);
     params.set("collection", collectionName);
@@ -63,14 +66,15 @@ export function CollectionViewer({ collectionName, onBack, onNavigateCollection 
     params.set("include_stale", "true");
     if (tuType !== "all") params.set("type", tuType);
 
-    fetch(`/api/trade-ups?${params}`, { credentials: "include" })
+    fetch(`/api/trade-ups?${params}`, { credentials: "include", signal: ctrl.signal })
       .then(r => r.json())
       .then(data => {
         setTradeUps(data.trade_ups || []);
         setTradeUpTotal(data.total || 0);
       })
       .catch(() => {})
-      .finally(() => setTradeUpsLoading(false));
+      .finally(() => { if (!ctrl.signal.aborted) setTradeUpsLoading(false); });
+    return () => ctrl.abort();
   }, [collectionName, tuSort, tuOrder, tuType, tuPage, filters]);
 
   const handleTuSort = (column: string) => {

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -190,9 +190,18 @@ function FilterPill({ label, summary, active, onClear, children }: {
         {active && (
           <span
             role="button"
+            tabIndex={0}
             aria-label={`Clear ${label} filter`}
             className="text-blue-400/70 hover:text-blue-200 text-sm leading-none -mr-1 px-0.5"
-            onClick={(e) => { e.stopPropagation(); onClear(); }}
+            onClick={(e) => { e.stopPropagation(); setExpanded(false); onClear(); }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                e.stopPropagation();
+                setExpanded(false);
+                onClear();
+              }
+            }}
           >&times;</span>
         )}
       </button>
@@ -212,12 +221,15 @@ function FilterPill({ label, summary, active, onClear, children }: {
   );
 }
 
-function RangeFilter({ label, minVal, maxVal, onMinChange, onMaxChange, step, unit }: {
+function RangeFilter({ label, minVal, maxVal, onMinChange, onMaxChange, onClear, step, unit }: {
   label: string;
   minVal: string;
   maxVal: string;
   onMinChange: (v: string) => void;
   onMaxChange: (v: string) => void;
+  /** Clears min AND max in ONE filters update — two sequential onMinChange/onMaxChange
+   *  calls would each spread the same stale filters object and resurrect the other value. */
+  onClear: () => void;
   step: number;
   unit: string;
 }) {
@@ -231,7 +243,7 @@ function RangeFilter({ label, minVal, maxVal, onMinChange, onMaxChange, step, un
       label={label}
       summary={summary}
       active={hasValue}
-      onClear={() => { onMinChange(""); onMaxChange(""); }}
+      onClear={onClear}
     >
       <div className="flex gap-2">
         <label className="flex flex-col gap-1 text-[0.72rem] text-muted-foreground flex-1">
@@ -379,22 +391,28 @@ export function FilterBar({ filters, onFiltersChange }: {
           <MarketFilter selected={filters.markets} onChange={(m) => update({ markets: m })} />
           <RangeFilter label="Profit" unit="$" step={1}
             minVal={filters.minProfit} maxVal={filters.maxProfit}
-            onMinChange={(v) => update({ minProfit: v })} onMaxChange={(v) => update({ maxProfit: v })} />
+            onMinChange={(v) => update({ minProfit: v })} onMaxChange={(v) => update({ maxProfit: v })}
+            onClear={() => update({ minProfit: "", maxProfit: "" })} />
           <RangeFilter label="ROI" unit="%" step={1}
             minVal={filters.minRoi} maxVal={filters.maxRoi}
-            onMinChange={(v) => update({ minRoi: v })} onMaxChange={(v) => update({ maxRoi: v })} />
+            onMinChange={(v) => update({ minRoi: v })} onMaxChange={(v) => update({ maxRoi: v })}
+            onClear={() => update({ minRoi: "", maxRoi: "" })} />
           <RangeFilter label="Cost" unit="$" step={10}
             minVal={filters.minCost} maxVal={filters.maxCost}
-            onMinChange={(v) => update({ minCost: v })} onMaxChange={(v) => update({ maxCost: v })} />
+            onMinChange={(v) => update({ minCost: v })} onMaxChange={(v) => update({ maxCost: v })}
+            onClear={() => update({ minCost: "", maxCost: "" })} />
           <RangeFilter label="Chance" unit="%" step={5}
             minVal={filters.minChance} maxVal={filters.maxChance}
-            onMinChange={(v) => update({ minChance: v })} onMaxChange={(v) => update({ maxChance: v })} />
+            onMinChange={(v) => update({ minChance: v })} onMaxChange={(v) => update({ maxChance: v })}
+            onClear={() => update({ minChance: "", maxChance: "" })} />
           <RangeFilter label="Max Loss" unit="$" step={10}
             minVal={filters.maxLoss} maxVal=""
-            onMinChange={(v) => update({ maxLoss: v })} onMaxChange={() => {}} />
+            onMinChange={(v) => update({ maxLoss: v })} onMaxChange={() => {}}
+            onClear={() => update({ maxLoss: "" })} />
           <RangeFilter label="Best Win" unit="$" step={10}
             minVal={filters.minWin} maxVal=""
-            onMinChange={(v) => update({ minWin: v })} onMaxChange={() => {}} />
+            onMinChange={(v) => update({ minWin: v })} onMaxChange={() => {}}
+            onClear={() => update({ minWin: "" })} />
         </div>
       </div>
     </div>

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -113,12 +113,21 @@ function AutocompleteInput({ placeholder, items, selected, onAdd, onRemove, rend
     <div className="relative w-[200px]" ref={ref}>
       <Input
         type="text"
-        className="h-8 text-sm"
+        className={`h-8 text-sm ${query ? "pr-7" : ""}`}
         placeholder={placeholder}
         value={query}
         onChange={(e) => { setQuery(e.target.value); setOpen(true); }}
         onFocus={() => setOpen(true)}
+        onKeyDown={(e) => { if (e.key === "Escape") setOpen(false); }}
       />
+      {query && (
+        <button
+          type="button"
+          aria-label="Clear search"
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground text-sm leading-none cursor-pointer"
+          onClick={() => { setQuery(""); setOpen(false); }}
+        >&times;</button>
+      )}
       {open && filtered.length > 0 && (
         <div className="absolute top-full left-0 right-0 z-[200] bg-popover border border-border border-t-0 rounded-b-md max-h-60 overflow-y-auto shadow-lg">
           {filtered.map(item => (
@@ -141,20 +150,20 @@ function AutocompleteInput({ placeholder, items, selected, onAdd, onRemove, rend
   );
 }
 
-function RangeFilter({ label, minVal, maxVal, onMinChange, onMaxChange, step, unit }: {
+/**
+ * Shared popover-pill shell: trigger pill (with inline clear × when active),
+ * click-outside dismissal, and a positioned popover with a header close.
+ * RangeFilter and MarketFilter supply only their popover body via children.
+ */
+function FilterPill({ label, summary, active, onClear, children }: {
   label: string;
-  minVal: string;
-  maxVal: string;
-  onMinChange: (v: string) => void;
-  onMaxChange: (v: string) => void;
-  step: number;
-  unit: string;
-  sliderMin?: number;
-  sliderMax?: number;
+  summary: string;
+  active: boolean;
+  onClear: () => void;
+  children: React.ReactNode;
 }) {
   const [expanded, setExpanded] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
-  const hasValue = !!(minVal || maxVal);
 
   // Click outside to dismiss
   useEffect(() => {
@@ -166,22 +175,26 @@ function RangeFilter({ label, minVal, maxVal, onMinChange, onMaxChange, step, un
     return () => document.removeEventListener("mousedown", handler);
   }, [expanded]);
 
-  const summary = hasValue
-    ? `${minVal ? `${unit}${minVal}` : "any"} – ${maxVal ? `${unit}${maxVal}` : "any"}`
-    : "any";
-
   return (
     <div className="relative" ref={ref}>
       <button
         className={`flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-full border whitespace-nowrap transition-colors cursor-pointer ${
-          hasValue
+          active
             ? "border-blue-500/40 bg-blue-500/10 text-blue-400"
             : "border-border text-muted-foreground hover:border-muted-foreground/50 hover:text-foreground"
         }`}
         onClick={() => setExpanded(e => !e)}
       >
         <span className="font-medium">{label}</span>
-        <span className={`text-[0.72rem] ${hasValue ? "text-blue-400" : "text-muted-foreground/60"}`}>{summary}</span>
+        <span className={`text-[0.72rem] ${active ? "text-blue-400" : "text-muted-foreground/60"}`}>{summary}</span>
+        {active && (
+          <span
+            role="button"
+            aria-label={`Clear ${label} filter`}
+            className="text-blue-400/70 hover:text-blue-200 text-sm leading-none -mr-1 px-0.5"
+            onClick={(e) => { e.stopPropagation(); onClear(); }}
+          >&times;</span>
+        )}
       </button>
       {expanded && (
         <div className="absolute top-[calc(100%+4px)] left-0 z-[200] bg-popover border border-border rounded-md p-3 min-w-[220px] shadow-lg">
@@ -190,29 +203,49 @@ function RangeFilter({ label, minVal, maxVal, onMinChange, onMaxChange, step, un
             <button
               className="text-muted-foreground hover:text-foreground text-sm cursor-pointer leading-none px-1"
               onClick={() => setExpanded(false)}
-            >×</button>
+            >&times;</button>
           </div>
-          <div className="flex gap-2">
-            <label className="flex flex-col gap-1 text-[0.72rem] text-muted-foreground flex-1">
-              <span>Min</span>
-              <Input type="number" value={minVal} onChange={(e) => onMinChange(e.target.value)}
-                placeholder={unit || "any"} step={step} className="h-7 text-xs [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [-moz-appearance:textfield]" />
-            </label>
-            <label className="flex flex-col gap-1 text-[0.72rem] text-muted-foreground flex-1">
-              <span>Max</span>
-              <Input type="number" value={maxVal} onChange={(e) => onMaxChange(e.target.value)}
-                placeholder={unit || "any"} step={step} className="h-7 text-xs [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [-moz-appearance:textfield]" />
-            </label>
-          </div>
-          {hasValue && (
-            <button
-              className="mt-2 text-[0.68rem] text-muted-foreground hover:text-foreground cursor-pointer"
-              onClick={() => { onMinChange(""); onMaxChange(""); }}
-            >Clear</button>
-          )}
+          {children}
         </div>
       )}
     </div>
+  );
+}
+
+function RangeFilter({ label, minVal, maxVal, onMinChange, onMaxChange, step, unit }: {
+  label: string;
+  minVal: string;
+  maxVal: string;
+  onMinChange: (v: string) => void;
+  onMaxChange: (v: string) => void;
+  step: number;
+  unit: string;
+}) {
+  const hasValue = !!(minVal || maxVal);
+  const summary = hasValue
+    ? `${minVal ? `${unit}${minVal}` : "any"} – ${maxVal ? `${unit}${maxVal}` : "any"}`
+    : "any";
+
+  return (
+    <FilterPill
+      label={label}
+      summary={summary}
+      active={hasValue}
+      onClear={() => { onMinChange(""); onMaxChange(""); }}
+    >
+      <div className="flex gap-2">
+        <label className="flex flex-col gap-1 text-[0.72rem] text-muted-foreground flex-1">
+          <span>Min</span>
+          <Input type="number" value={minVal} onChange={(e) => onMinChange(e.target.value)}
+            placeholder={unit || "any"} step={step} className="h-7 text-xs [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [-moz-appearance:textfield]" />
+        </label>
+        <label className="flex flex-col gap-1 text-[0.72rem] text-muted-foreground flex-1">
+          <span>Max</span>
+          <Input type="number" value={maxVal} onChange={(e) => onMaxChange(e.target.value)}
+            placeholder={unit || "any"} step={step} className="h-7 text-xs [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [-moz-appearance:textfield]" />
+        </label>
+      </div>
+    </FilterPill>
   );
 }
 
@@ -220,76 +253,38 @@ function MarketFilter({ selected, onChange }: {
   selected: string[];
   onChange: (markets: string[]) => void;
 }) {
-  const [expanded, setExpanded] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
   const hasValue = selected.length > 0;
-
-  useEffect(() => {
-    if (!expanded) return;
-    const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setExpanded(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [expanded]);
-
   const summary = hasValue
     ? selected.map(m => AVAILABLE_MARKETS.find(am => am.value === m)?.label || m).join(", ")
     : "any";
 
   return (
-    <div className="relative" ref={ref}>
-      <button
-        className={`flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-full border whitespace-nowrap transition-colors cursor-pointer ${
-          hasValue
-            ? "border-blue-500/40 bg-blue-500/10 text-blue-400"
-            : "border-border text-muted-foreground hover:border-muted-foreground/50 hover:text-foreground"
-        }`}
-        onClick={() => setExpanded(e => !e)}
-      >
-        <span className="font-medium">Market</span>
-        <span className={`text-[0.72rem] ${hasValue ? "text-blue-400" : "text-muted-foreground/60"}`}>{summary}</span>
-      </button>
-      {expanded && (
-        <div className="absolute top-[calc(100%+4px)] left-0 z-[200] bg-popover border border-border rounded-md p-3 min-w-[180px] shadow-lg">
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-xs font-medium text-foreground">Market</span>
-            <button
-              className="text-muted-foreground hover:text-foreground text-sm cursor-pointer leading-none px-1"
-              onClick={() => setExpanded(false)}
-            >×</button>
-          </div>
-          <div className="flex flex-col gap-2">
-            {AVAILABLE_MARKETS.map(m => (
-              <label key={m.value} className="flex items-center gap-2 text-xs text-popover-foreground cursor-pointer select-none">
-                <input
-                  type="checkbox"
-                  checked={selected.includes(m.value)}
-                  onChange={(e) => {
-                    const next = e.target.checked
-                      ? [...selected, m.value]
-                      : selected.filter(x => x !== m.value);
-                    onChange(next);
-                  }}
-                  className="rounded border-border"
-                />
-                {m.label}
-              </label>
-            ))}
-          </div>
-          {hasValue && (
-            <button
-              className="mt-2 text-[0.68rem] text-muted-foreground hover:text-foreground cursor-pointer"
-              onClick={() => onChange([])}
-            >Clear</button>
-          )}
-        </div>
-      )}
-    </div>
+    <FilterPill label="Market" summary={summary} active={hasValue} onClear={() => onChange([])}>
+      <div className="flex flex-col gap-2">
+        {AVAILABLE_MARKETS.map(m => (
+          <label key={m.value} className="flex items-center gap-2 text-xs text-popover-foreground cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={selected.includes(m.value)}
+              onChange={(e) => {
+                const next = e.target.checked
+                  ? [...selected, m.value]
+                  : selected.filter(x => x !== m.value);
+                onChange(next);
+              }}
+              className="rounded border-border"
+            />
+            {m.label}
+          </label>
+        ))}
+      </div>
+    </FilterPill>
   );
 }
 
 export function FilterChips({ filters, onUpdate }: { filters: Filters; onUpdate: (f: Filters) => void }) {
+  // Range/market filters are represented (and cleared) on their pills.
+  // Chips exist only for selections without a pill: skins and collections.
   const chips: { label: string; onRemove: () => void }[] = [];
 
   for (const s of filters.skins) {
@@ -298,30 +293,8 @@ export function FilterChips({ filters, onUpdate }: { filters: Filters; onUpdate:
   for (const c of filters.collections) {
     chips.push({ label: `Collection: ${c}`, onRemove: () => onUpdate({ ...filters, collections: filters.collections.filter(x => x !== c) }) });
   }
-  if (filters.minProfit || filters.maxProfit) {
-    const lbl = `Profit: ${filters.minProfit ? `$${filters.minProfit}` : "any"} – ${filters.maxProfit ? `$${filters.maxProfit}` : "any"}`;
-    chips.push({ label: lbl, onRemove: () => onUpdate({ ...filters, minProfit: "", maxProfit: "" }) });
-  }
-  if (filters.minRoi || filters.maxRoi) {
-    const lbl = `ROI: ${filters.minRoi ? `${filters.minRoi}%` : "any"} – ${filters.maxRoi ? `${filters.maxRoi}%` : "any"}`;
-    chips.push({ label: lbl, onRemove: () => onUpdate({ ...filters, minRoi: "", maxRoi: "" }) });
-  }
-  if (filters.minCost || filters.maxCost) {
-    const lbl = `Cost: ${filters.minCost ? `$${filters.minCost}` : "any"} – ${filters.maxCost ? `$${filters.maxCost}` : "any"}`;
-    chips.push({ label: lbl, onRemove: () => onUpdate({ ...filters, minCost: "", maxCost: "" }) });
-  }
-  if (filters.minChance || filters.maxChance) {
-    const lbl = `Chance: ${filters.minChance ? `${filters.minChance}%` : "any"} – ${filters.maxChance ? `${filters.maxChance}%` : "any"}`;
-    chips.push({ label: lbl, onRemove: () => onUpdate({ ...filters, minChance: "", maxChance: "" }) });
-  }
-  if (filters.maxLoss) {
-    chips.push({ label: `Max Loss: $${filters.maxLoss}`, onRemove: () => onUpdate({ ...filters, maxLoss: "" }) });
-  }
-  if (filters.minWin) {
-    chips.push({ label: `Min Best Win: $${filters.minWin}`, onRemove: () => onUpdate({ ...filters, minWin: "" }) });
-  }
 
-  if (chips.length === 0) return null;
+  if (chips.length === 0 && !hasActiveFilters(filters)) return null;
 
   return (
     <div className="flex gap-1.5 flex-wrap mt-2 mb-1 items-center">

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -151,8 +151,10 @@ function AutocompleteInput({ placeholder, items, selected, onAdd, onRemove, rend
 }
 
 /**
- * Shared popover-pill shell: trigger pill (with inline clear × when active),
- * click-outside dismissal, and a positioned popover with a header close.
+ * Shared popover-pill shell: trigger button + sibling clear button (when active)
+ * inside a non-interactive pill-styled wrapper — nesting the clear control in the
+ * trigger would violate the button content model and hide it from AT.
+ * Click-outside dismissal and a positioned popover with a header close.
  * RangeFilter and MarketFilter supply only their popover body via children.
  */
 function FilterPill({ label, summary, active, onClear, children }: {
@@ -164,6 +166,7 @@ function FilterPill({ label, summary, active, onClear, children }: {
 }) {
   const [expanded, setExpanded] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
   // Click outside to dismiss
   useEffect(() => {
@@ -177,34 +180,34 @@ function FilterPill({ label, summary, active, onClear, children }: {
 
   return (
     <div className="relative" ref={ref}>
-      <button
-        className={`flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-full border whitespace-nowrap transition-colors cursor-pointer ${
+      <div
+        className={`flex items-center rounded-full border whitespace-nowrap transition-colors ${
           active
             ? "border-blue-500/40 bg-blue-500/10 text-blue-400"
             : "border-border text-muted-foreground hover:border-muted-foreground/50 hover:text-foreground"
         }`}
-        onClick={() => setExpanded(e => !e)}
       >
-        <span className="font-medium">{label}</span>
-        <span className={`text-[0.72rem] ${active ? "text-blue-400" : "text-muted-foreground/60"}`}>{summary}</span>
+        <button
+          ref={triggerRef}
+          className={`flex items-center gap-1.5 pl-3 py-1.5 text-xs cursor-pointer ${active ? "pr-1" : "pr-3"}`}
+          onClick={() => setExpanded(e => !e)}
+          aria-expanded={expanded}
+        >
+          <span className="font-medium">{label}</span>
+          <span className={`text-[0.72rem] ${active ? "text-blue-400" : "text-muted-foreground/60"}`}>{summary}</span>
+        </button>
         {active && (
-          <span
-            role="button"
-            tabIndex={0}
+          <button
             aria-label={`Clear ${label} filter`}
-            className="text-blue-400/70 hover:text-blue-200 text-sm leading-none -mr-1 px-0.5"
-            onClick={(e) => { e.stopPropagation(); setExpanded(false); onClear(); }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                e.stopPropagation();
-                setExpanded(false);
-                onClear();
-              }
+            className="pr-2.5 pl-1 py-1.5 text-sm leading-none text-blue-400/70 hover:text-blue-200 cursor-pointer"
+            onClick={() => {
+              setExpanded(false);
+              onClear();
+              triggerRef.current?.focus(); // clear button unmounts — keep focus in the pill
             }}
-          >&times;</span>
+          >&times;</button>
         )}
-      </button>
+      </div>
       {expanded && (
         <div className="absolute top-[calc(100%+4px)] left-0 z-[200] bg-popover border border-border rounded-md p-3 min-w-[220px] shadow-lg">
           <div className="flex items-center justify-between mb-2">

--- a/src/components/ProductCTA.tsx
+++ b/src/components/ProductCTA.tsx
@@ -19,7 +19,7 @@ const COPY: Record<CTAVariant, {
 }> = {
   blog: {
     headline: "See live profitable trade-ups right now",
-    subtext: "TradeUpBot scans CSFloat, DMarket, and Skinport continuously. Every trade-up is built from real, buyable listings — fee-adjusted profit shown upfront. Free tier available.",
+    subtext: "TradeUpBot scans CSFloat, DMarket, and Skinport continuously. Every trade-up is built from live listings, with marketplace fees factored into profit. Free tier available.",
     primaryLabel: "Browse trade-ups",
     primaryHref: "/trade-ups",
     secondaryLabel: "Try the calculator",
@@ -28,7 +28,7 @@ const COPY: Record<CTAVariant, {
   },
   calculator: {
     headline: "Want pre-built profitable trade-ups?",
-    subtext: "TradeUpBot scans live marketplace listings and surfaces the contracts that actually profit — with fee-adjusted EV and float-precise output pricing. Free tier available.",
+    subtext: "TradeUpBot scans live marketplace listings and lists the contracts with positive fee-adjusted EV and float-precise output pricing. Free tier available.",
     primaryLabel: "Browse trade-ups",
     primaryHref: "/trade-ups",
     secondaryLabel: "See features",
@@ -37,7 +37,7 @@ const COPY: Record<CTAVariant, {
   },
   "trade-ups": {
     headline: "Build your own trade-up from scratch",
-    subtext: "Paste any 10 skins, set your floats and prices, and the calculator shows you exact output probabilities, expected value, and fee-adjusted profit — before you spend a cent.",
+    subtext: "Enter any 10 skins with floats and prices. The calculator returns exact output probabilities, expected value, and fee-adjusted profit before you buy anything.",
     primaryLabel: "Try the calculator",
     primaryHref: "/calculator",
     secondaryLabel: "See features",

--- a/src/components/TradeUpTable.tsx
+++ b/src/components/TradeUpTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useMemo, type ReactNode } from "react";
+import { Fragment, useState, useCallback, useEffect, useMemo, useRef, type ReactNode } from "react";
 import type { TradeUp, TradeUpInput } from "../../shared/types.js";
 import { condAbbr, csfloatSearchUrl } from "../utils/format.js";
 import { useCurrency } from "../contexts/CurrencyContext.js";
@@ -159,6 +159,7 @@ function ClaimTimer({ expiresAt }: { expiresAt: string }) {
       const diff = new Date(expiresAt).getTime() - Date.now();
       setMinsLeft(Math.max(0, Math.ceil(diff / 60000)));
     };
+    tick();
     const id = setInterval(tick, 15000);
     return () => clearInterval(id);
   }, [expiresAt]);
@@ -225,30 +226,37 @@ export function TradeUpTable({ tradeUps, sort, order, onSort, onNavigateSkin, on
   // Lazy-loaded outcomes and inputs (not included in list response to save bandwidth)
   const [loadedOutcomes, setLoadedOutcomes] = useState<Map<number, TradeUp["outcomes"]>>(new Map());
   const [loadedInputs, setLoadedInputs] = useState<Map<number, TradeUp["inputs"]>>(new Map());
+  // Guard against duplicate in-flight detail fetches (rapid collapse/re-expand)
+  const inflightDetails = useRef(new Set<string>());
 
   const handleExpand = useCallback(async (tuId: number) => {
     if (expandedId === tuId) { setExpandedId(null); return; }
     setExpandedId(tuId);
-    // Load outcomes + inputs if not cached
+    // Load outcomes + inputs if not cached; results are keyed by trade-up id,
+    // so a late response can never land in another row's state.
     const promises: Promise<void>[] = [];
-    if (!loadedOutcomes.has(tuId)) {
+    const outcomesKey = `o:${tuId}`;
+    if (!loadedOutcomes.has(tuId) && !inflightDetails.current.has(outcomesKey)) {
+      inflightDetails.current.add(outcomesKey);
       promises.push(
         fetch(`/api/trade-up/${tuId}/outcomes`).then(async res => {
           if (res.ok) {
             const data = await res.json();
             setLoadedOutcomes(prev => new Map(prev).set(tuId, data.outcomes || []));
           }
-        }).catch(() => {})
+        }).catch(() => {}).finally(() => { inflightDetails.current.delete(outcomesKey); })
       );
     }
-    if (!loadedInputs.has(tuId)) {
+    const inputsKey = `i:${tuId}`;
+    if (!loadedInputs.has(tuId) && !inflightDetails.current.has(inputsKey)) {
+      inflightDetails.current.add(inputsKey);
       promises.push(
         fetch(`/api/trade-up/${tuId}/inputs`).then(async res => {
           if (res.ok) {
             const data = await res.json();
             setLoadedInputs(prev => new Map(prev).set(tuId, data.inputs || []));
           }
-        }).catch(() => {})
+        }).catch(() => {}).finally(() => { inflightDetails.current.delete(inputsKey); })
       );
     }
     await Promise.all(promises);
@@ -607,9 +615,8 @@ export function TradeUpTable({ tradeUps, sort, order, onSort, onNavigateSkin, on
         </thead>
         <tbody>
           {preparedTradeUps.map(({ tu, chance, best, worst, inputSummary, inputCount, realInputCount, missingCount, displayStatus, collections, age }) => (
-            <>
+            <Fragment key={tu.id}>
               <tr
-                key={tu.id}
                 className={`cursor-pointer hover:bg-muted group/row ${displayStatus === 'stale' ? 'opacity-55 border-l-[3px] border-l-red-500' : displayStatus === 'partial' ? 'border-l-[3px] border-l-yellow-500' : ''}`}
                 onClick={() => handleExpand(tu.id)}
               >
@@ -742,13 +749,13 @@ export function TradeUpTable({ tradeUps, sort, order, onSort, onNavigateSkin, on
                 </td>
               </tr>
               {expandedId === tu.id && (
-                <tr key={`${tu.id}-expanded`}>
+                <tr>
                   <td colSpan={11} className="p-0">
                     {renderExpanded(tu)}
                   </td>
                 </tr>
               )}
-            </>
+            </Fragment>
           ))}
         </tbody>
       </table>

--- a/src/components/data-viewer/SkinDetailPanel.tsx
+++ b/src/components/data-viewer/SkinDetailPanel.tsx
@@ -61,19 +61,24 @@ export function SkinDetailPanel({ skinName, stattrak, onClose, onNavigateCollect
   const [filtersOpen, setFiltersOpen] = useState(false);
 
   useEffect(() => {
+    const ctrl = new AbortController();
     setLoading(true);
     const stParam = stattrak ? "&stattrak=1" : "";
-    fetch(`/api/skin-data/${encodeURIComponent(skinName)}?_=${Date.now()}${stParam}`)
+    fetch(`/api/skin-data/${encodeURIComponent(skinName)}?_=${Date.now()}${stParam}`, { signal: ctrl.signal })
       .then(r => r.json())
       .then(setDetail)
       .catch(() => {})
-      .finally(() => setLoading(false));
+      .finally(() => { if (!ctrl.signal.aborted) setLoading(false); });
+    return () => ctrl.abort();
   }, [skinName, stattrak]);
 
   useEffect(() => {
     setFloatRange({ min: null, max: null });
     setTimeRange({ from: null, to: null });
     setFiltersOpen(false);
+    // A phase selected on a previous Doppler skin would filter every listing
+    // of the next skin out (non-Doppler listings have no phase)
+    setSelectedPhase(null);
   }, [skinName]);
 
   const toggleSeries = (key: SeriesKey) => {

--- a/src/hooks/useDebouncedValue.ts
+++ b/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from "react";
+
+/** Returns `value` after it has been stable for `delayMs`. Used to settle filter typing before fetching. */
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/src/hooks/useStatus.ts
+++ b/src/hooks/useStatus.ts
@@ -16,6 +16,7 @@ export function useStatus(enabled = true, pollInterval = 60_000) {
   const prevCount = useRef(0);
   const prevStatus = useRef<SyncStatus | null>(null);
   const fetchSeq = useRef(0);
+  const lastAppliedSeq = useRef(0);
 
   const fetchStatus = useCallback(async () => {
     if (!enabled) return null;
@@ -23,8 +24,10 @@ export function useStatus(enabled = true, pollInterval = 60_000) {
     try {
       const res = await fetch("/api/status");
       const data: SyncStatus = await res.json();
-      // A newer fetch (manual refresh vs poll) finished first — drop this stale response
-      if (seq !== fetchSeq.current) return null;
+      // A newer fetch (manual refresh vs poll) already applied its response — drop this stale one.
+      // Failed requests never bump lastAppliedSeq, so an older in-flight success still lands.
+      if (seq <= lastAppliedSeq.current) return null;
+      lastAppliedSeq.current = seq;
       // Compute diffs against previous status
       if (prevStatus.current) {
         const p = prevStatus.current;

--- a/src/hooks/useStatus.ts
+++ b/src/hooks/useStatus.ts
@@ -15,12 +15,16 @@ export function useStatus(enabled = true, pollInterval = 60_000) {
   const [newDataHint, setNewDataHint] = useState(false);
   const prevCount = useRef(0);
   const prevStatus = useRef<SyncStatus | null>(null);
+  const fetchSeq = useRef(0);
 
   const fetchStatus = useCallback(async () => {
     if (!enabled) return null;
+    const seq = ++fetchSeq.current;
     try {
       const res = await fetch("/api/status");
       const data: SyncStatus = await res.json();
+      // A newer fetch (manual refresh vs poll) finished first — drop this stale response
+      if (seq !== fetchSeq.current) return null;
       // Compute diffs against previous status
       if (prevStatus.current) {
         const p = prevStatus.current;

--- a/src/pages/CalculatorPage.tsx
+++ b/src/pages/CalculatorPage.tsx
@@ -65,8 +65,17 @@ function SkinSearchInput({
   const [results, setResults] = useState<SearchResult[]>([]);
   const [isOpen, setIsOpen] = useState(false);
   const [loading, setLoading] = useState(false);
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const debounceRef = useRef<number | undefined>(undefined);
+  const abortRef = useRef<AbortController | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  // Cancel pending debounce/fetch on unmount
+  useEffect(() => {
+    return () => {
+      clearTimeout(debounceRef.current);
+      abortRef.current?.abort();
+    };
+  }, []);
 
   useEffect(() => {
     setQuery(value);
@@ -84,29 +93,34 @@ function SkinSearchInput({
   }, []);
 
   const search = useCallback((q: string) => {
+    abortRef.current?.abort();
     if (q.length < 2) {
       setResults([]);
       setIsOpen(false);
+      setLoading(false);
       return;
     }
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
     setLoading(true);
-    fetch(`/api/calculator/search?q=${encodeURIComponent(q)}`)
+    fetch(`/api/calculator/search?q=${encodeURIComponent(q)}`, { signal: ctrl.signal })
       .then(r => r.json())
       .then(data => {
+        if (ctrl.signal.aborted) return;
         setResults(data.results || []);
         setIsOpen(true);
         setLoading(false);
       })
       .catch(() => {
-        setLoading(false);
+        if (!ctrl.signal.aborted) setLoading(false);
       });
   }, []);
 
   const handleChange = (val: string) => {
     setQuery(val);
     if (resolved) onClear();
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => search(val), 250);
+    clearTimeout(debounceRef.current);
+    debounceRef.current = window.setTimeout(() => search(val), 250);
   };
 
   const handleSelect = (result: SearchResult) => {

--- a/src/pages/FaqPage.tsx
+++ b/src/pages/FaqPage.tsx
@@ -61,7 +61,7 @@ export function FaqPage() {
               "name": "How does TradeUpBot find profitable trade-ups?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "TradeUpBot builds every trade-up from real, buyable listings on CSFloat, DMarket, and Skinport. The engine scans marketplace listings continuously, tests thousands of input combinations across 45+ float targets, and computes the expected profit and probability of each outcome. Every trade-up links to listings you can purchase right now, with exact floats and exact prices."
+                "text": "TradeUpBot builds every trade-up from real, buyable listings on CSFloat, DMarket, Skinport, and Buff.market. The engine scans marketplace listings continuously, tests thousands of input combinations across 45+ float targets, and computes the expected profit and probability of each outcome. Every trade-up links to listings you can purchase right now, with exact floats and exact prices."
               }
             },
             {
@@ -85,7 +85,7 @@ export function FaqPage() {
               "name": "What does \"Verify\" do?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "Verify checks whether all input listings for a trade-up are still available on their marketplaces and at what price. If a listing has been sold or delisted, verification flags it so you know the trade-up may no longer be viable. The trade-up's cost, profit, and EV update from the response."
+                "text": "Verify checks whether all input listings for a trade-up are still available on their marketplaces and at what price. If a listing has been sold or delisted, verification flags it so you know the trade-up may no longer be viable. The trade-up's cost, profit, and ROI update from the response."
               }
             },
             {
@@ -109,7 +109,7 @@ export function FaqPage() {
               "name": "What marketplaces are supported?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "TradeUpBot sources input listings from three marketplaces: CSFloat (primary source for Covert skins and sale-based pricing), DMarket (broad coverage across all rarity tiers at 2 req/s), and Skinport (passive WebSocket feed, no rate limits). Each marketplace has different buyer fees which are factored into the total input cost calculations."
+                "text": "TradeUpBot sources input listings from four marketplaces: CSFloat (primary source for Covert skins and sale-based pricing), DMarket (broad coverage across all rarity tiers at 2 req/s), Skinport (passive WebSocket feed, no rate limits), and Buff.market (buy-now listings fetched continuously in a separate process). Each marketplace has different buyer fees which are factored into the total input cost calculations."
               }
             },
             {
@@ -117,7 +117,7 @@ export function FaqPage() {
               "name": "Why are some trade-ups marked as stale or partial?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "Marketplace listings get bought and delisted constantly. Partial means some of a trade-up's input listings are gone. Stale means all of them are gone. The engine searches for replacement listings each cycle and updates the status when it finds them."
+                "text": "Marketplace listings get bought and delisted constantly. Partial means some of a trade-up's inputs are no longer available — sold, delisted, or claimed by another user. Stale means none of them are. The engine searches for replacement listings each cycle and updates the status when it finds them."
               }
             },
             {
@@ -176,7 +176,7 @@ export function FaqPage() {
             <FaqItem question="How does TradeUpBot find profitable trade-ups?">
               <p>
                 TradeUpBot builds every trade-up from real, buyable listings on CSFloat, DMarket,
-                and Skinport. The engine scans marketplace listings continuously, tests thousands
+                Skinport, and Buff.market. The engine scans marketplace listings continuously, tests thousands
                 of input combinations across 45+ float targets, and computes the expected profit
                 and probability of each outcome.
               </p>
@@ -225,7 +225,7 @@ export function FaqPage() {
                 Verify checks whether all input listings for a trade-up are still available on
                 their marketplaces and at what price. If a listing has been sold or delisted,
                 verification flags it so you know the trade-up may no longer be viable. The
-                trade-up's cost, profit, and EV update from the response.
+                trade-up's cost, profit, and ROI update from the response.
               </p>
             </FaqItem>
 
@@ -249,12 +249,13 @@ export function FaqPage() {
 
             <FaqItem question="What marketplaces are supported?">
               <p>
-                TradeUpBot sources input listings from three marketplaces:
+                TradeUpBot sources input listings from four marketplaces:
               </p>
               <ul className="list-disc list-inside ml-2 space-y-1">
                 <li><strong className="text-foreground">CSFloat</strong> — primary source for Covert skins and sale-based pricing</li>
                 <li><strong className="text-foreground">DMarket</strong> — broad coverage across all rarity tiers at 2 req/s</li>
                 <li><strong className="text-foreground">Skinport</strong> — passive WebSocket feed, no rate limits</li>
+                <li><strong className="text-foreground">Buff.market</strong> — buy-now listings fetched continuously in a separate process</li>
               </ul>
               <p>
                 Each marketplace has different buyer fees which are factored into the total
@@ -266,8 +267,9 @@ export function FaqPage() {
             <FaqItem question="Why are some trade-ups marked as stale or partial?">
               <p>
                 Marketplace listings get bought and delisted constantly. <strong className="text-foreground">Partial</strong> means
-                some of a trade-up's input listings are gone. <strong className="text-foreground">Stale</strong> means all of them
-                are gone. The engine searches for replacement listings each cycle and updates
+                some of a trade-up's inputs are no longer available — sold, delisted, or claimed by
+                another user. <strong className="text-foreground">Stale</strong> means none of them are. The engine searches
+                for replacement listings each cycle and updates
                 the status when it finds them.
               </p>
             </FaqItem>

--- a/src/pages/FaqPage.tsx
+++ b/src/pages/FaqPage.tsx
@@ -61,7 +61,7 @@ export function FaqPage() {
               "name": "How does TradeUpBot find profitable trade-ups?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "Unlike other tools that use theoretical calculations with idealized float values, TradeUpBot builds every trade-up from real, buyable listings on CSFloat, DMarket, and Skinport. Our engine continuously scans marketplace listings, tests thousands of input combinations across 45+ float targets, and evaluates the expected profit and probability of each outcome. Every trade-up you see on the platform links to actual listings you can purchase right now, with exact floats, exact prices, and deterministic outcomes."
+                "text": "TradeUpBot builds every trade-up from real, buyable listings on CSFloat, DMarket, and Skinport. The engine scans marketplace listings continuously, tests thousands of input combinations across 45+ float targets, and computes the expected profit and probability of each outcome. Every trade-up links to listings you can purchase right now, with exact floats and exact prices."
               }
             },
             {
@@ -85,7 +85,7 @@ export function FaqPage() {
               "name": "What does \"Verify\" do?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "Verify checks whether all the input listings for a trade-up are still available on their respective marketplaces and at what price. This gives you up-to-the-moment confirmation before you commit to buying. If a listing has been sold or delisted, verification will flag it so you know the trade-up may no longer be viable."
+                "text": "Verify checks whether all input listings for a trade-up are still available on their marketplaces and at what price. If a listing has been sold or delisted, verification flags it so you know the trade-up may no longer be viable. The trade-up's cost, profit, and EV update from the response."
               }
             },
             {
@@ -101,7 +101,7 @@ export function FaqPage() {
               "name": "How often is data updated?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "Data is updated continuously. The discovery engine runs in approximately 20-minute cycles, scanning for new listings and recalculating trade-ups each cycle. DMarket listings are fetched continuously at 2 requests per second in a separate process. Skinport data streams in via a live WebSocket connection."
+                "text": "The discovery engine runs in approximately 20-minute cycles, scanning for new listings and recalculating trade-ups each cycle. DMarket listings are fetched continuously at 2 requests per second in a separate process. Skinport data streams in via a live WebSocket connection."
               }
             },
             {
@@ -117,7 +117,7 @@ export function FaqPage() {
               "name": "Why are some trade-ups marked as stale or partial?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "Listings on marketplaces are constantly being bought and delisted. When one or more inputs in a trade-up are no longer available, the trade-up is marked as partial (some inputs missing) or stale (not updated in recent cycles). The engine attempts to find replacement listings each cycle, but availability depends on market conditions."
+                "text": "Marketplace listings get bought and delisted constantly. Partial means some of a trade-up's input listings are gone. Stale means all of them are gone. The engine searches for replacement listings each cycle and updates the status when it finds them."
               }
             },
             {
@@ -141,7 +141,7 @@ export function FaqPage() {
               "name": "What are the rate limits?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "Rate limits apply to Pro tier actions. Verify: 20/hour. Claim: 10/hour (up to 5 active claims). These limits exist to ensure fair access and prevent abuse of marketplace APIs."
+                "text": "Rate limits apply to Pro tier actions. Verify: 20/hour. Claim: 10/hour, up to 5 active claims. Limits keep marketplace API usage within bounds."
               }
             }
           ]
@@ -175,15 +175,14 @@ export function FaqPage() {
 
             <FaqItem question="How does TradeUpBot find profitable trade-ups?">
               <p>
-                Unlike other tools that use theoretical calculations with idealized float values,
                 TradeUpBot builds every trade-up from real, buyable listings on CSFloat, DMarket,
-                and Skinport. Our engine continuously scans marketplace listings, tests thousands
-                of input combinations across 45+ float targets, and evaluates the expected profit
+                and Skinport. The engine scans marketplace listings continuously, tests thousands
+                of input combinations across 45+ float targets, and computes the expected profit
                 and probability of each outcome.
               </p>
               <p>
-                Every trade-up you see on the platform links to actual listings you can purchase
-                right now, with exact floats, exact prices, and deterministic outcomes.
+                Every trade-up links to listings you can purchase right now, with exact floats
+                and exact prices.
               </p>
               <BlogLink slug="profitable-trade-ups-theory-vs-reality" title="Theory vs Reality" />
             </FaqItem>
@@ -223,10 +222,10 @@ export function FaqPage() {
 
             <FaqItem question='What does "Verify" do?'>
               <p>
-                Verify checks whether all the input listings for a trade-up are still available
-                on their respective marketplaces and at what price. This gives you up-to-the-moment
-                confirmation before you commit to buying. If a listing has been sold or delisted,
-                verification will flag it so you know the trade-up may no longer be viable.
+                Verify checks whether all input listings for a trade-up are still available on
+                their marketplaces and at what price. If a listing has been sold or delisted,
+                verification flags it so you know the trade-up may no longer be viable. The
+                trade-up's cost, profit, and EV update from the response.
               </p>
             </FaqItem>
 
@@ -241,10 +240,10 @@ export function FaqPage() {
 
             <FaqItem question="How often is data updated?">
               <p>
-                Data is updated continuously. The discovery engine runs in approximately 20-minute
-                cycles, scanning for new listings and recalculating trade-ups each cycle.
-                DMarket listings are fetched continuously at 2 requests per second in a separate
-                process. Skinport data streams in via a live WebSocket connection.
+                The discovery engine runs in approximately 20-minute cycles, scanning for new
+                listings and recalculating trade-ups each cycle. DMarket listings are fetched
+                continuously at 2 requests per second in a separate process. Skinport data
+                streams in via a live WebSocket connection.
               </p>
             </FaqItem>
 
@@ -266,11 +265,10 @@ export function FaqPage() {
 
             <FaqItem question="Why are some trade-ups marked as stale or partial?">
               <p>
-                Listings on marketplaces are constantly being bought and delisted. When one or
-                more inputs in a trade-up are no longer available, the trade-up is marked as
-                partial (some inputs missing) or stale (not updated in recent cycles). The engine
-                attempts to find replacement listings each cycle, but availability depends on
-                market conditions.
+                Marketplace listings get bought and delisted constantly. <strong className="text-foreground">Partial</strong> means
+                some of a trade-up's input listings are gone. <strong className="text-foreground">Stale</strong> means all of them
+                are gone. The engine searches for replacement listings each cycle and updates
+                the status when it finds them.
               </p>
             </FaqItem>
 
@@ -313,7 +311,7 @@ export function FaqPage() {
                 <li><strong className="text-foreground">Claim</strong> — 10/hour (up to 5 active claims)</li>
               </ul>
               <p>
-                These limits exist to ensure fair access and prevent abuse of marketplace APIs.
+                Limits keep marketplace API usage within bounds.
               </p>
             </FaqItem>
           </div>

--- a/src/pages/FeaturesPage.tsx
+++ b/src/pages/FeaturesPage.tsx
@@ -29,14 +29,14 @@ export function FeaturesPage() {
             <section>
               <h2 className="text-xl font-bold mb-3">Real marketplace listings</h2>
               <p className="text-sm text-muted-foreground leading-relaxed mb-4">
-                Every trade-up is built from skins currently listed on CSFloat, DMarket, and Skinport.
+                Every trade-up is built from skins currently listed on CSFloat, DMarket, Skinport, and Buff.market.
                 Each input links to a specific listing with its actual float and price, so the cost
                 you see is the cost you pay.
               </p>
-              <div className="grid sm:grid-cols-3 gap-4">
+              <div className="grid sm:grid-cols-2 gap-4">
                 <div className="border border-border rounded-lg p-4">
                   <div className="text-sm font-semibold mb-1">CSFloat</div>
-                  <p className="text-xs text-muted-foreground">Primary source for Covert skins and sale-based output pricing. Sale history gives the most reliable price signal of the three sources.</p>
+                  <p className="text-xs text-muted-foreground">Primary source for Covert skins and sale-based output pricing. Sale history gives the most reliable price signal.</p>
                 </div>
                 <div className="border border-border rounded-lg p-4">
                   <div className="text-sm font-semibold mb-1">DMarket</div>
@@ -45,6 +45,10 @@ export function FeaturesPage() {
                 <div className="border border-border rounded-lg p-4">
                   <div className="text-sm font-semibold mb-1">Skinport</div>
                   <p className="text-xs text-muted-foreground">Passive WebSocket feed with no rate limits. Provides additional price data and listing availability.</p>
+                </div>
+                <div className="border border-border rounded-lg p-4">
+                  <div className="text-sm font-semibold mb-1">Buff.market</div>
+                  <p className="text-xs text-muted-foreground">Buy-now listings fetched continuously in a separate process. Extends input coverage beyond the other three.</p>
                 </div>
               </div>
             </section>
@@ -82,7 +86,7 @@ export function FeaturesPage() {
               <h2 className="text-xl font-bold mb-3">Verify system</h2>
               <p className="text-sm text-muted-foreground leading-relaxed mb-4">
                 Before spending money, hit Verify. It calls each marketplace's API to confirm every
-                input listing still exists and at what price. The trade-up's cost, profit, and EV
+                input listing still exists and at what price. The trade-up's cost, profit, and ROI
                 update from the response.
               </p>
               <div className="flex gap-6 text-sm">
@@ -98,7 +102,8 @@ export function FeaturesPage() {
               <h2 className="text-xl font-bold mb-3">Claim system</h2>
               <p className="text-sm text-muted-foreground leading-relaxed mb-4">
                 Pro users can claim a trade-up to hide its listings from all other TradeUpBot users
-                for 30 minutes. During that window, no other user can see or buy those inputs.
+                for 30 minutes. Anyone shopping the marketplace directly can still buy the inputs —
+                a claim removes your TradeUpBot competition, not the listings themselves.
               </p>
               <div className="flex gap-6 text-sm flex-wrap">
                 <div>
@@ -182,7 +187,7 @@ export function FeaturesPage() {
           {/* CTA */}
           <div className="mt-16 pt-10 border-t border-border text-center">
             <h2 className="text-xl font-bold mb-3">Start free</h2>
-            <p className="text-sm text-muted-foreground mb-6">Sign in with Steam. The free tier shows every trade-up on a 3-hour delay.</p>
+            <p className="text-sm text-muted-foreground mb-6">Sign in with Steam. The free tier shows trade-up data on a 3-hour delay; contracts whose inputs sell in the meantime drop out.</p>
             <a
               href={authHref("/trade-ups")}
               onClick={() => trackEvent("sign_up_start", { location: "features_cta" })}

--- a/src/pages/FeaturesPage.tsx
+++ b/src/pages/FeaturesPage.tsx
@@ -19,7 +19,7 @@ export function FeaturesPage() {
         <div className="mx-auto max-w-4xl px-6">
           <h1 className="text-3xl sm:text-4xl font-bold mb-2">Features</h1>
           <p className="text-muted-foreground mb-12 max-w-2xl">
-            Everything TradeUpBot does to find, analyze, and help you execute profitable CS2 trade-up contracts.
+            How TradeUpBot finds, prices, and locks profitable CS2 trade-up contracts.
           </p>
 
           {/* Feature sections */}
@@ -29,14 +29,14 @@ export function FeaturesPage() {
             <section>
               <h2 className="text-xl font-bold mb-3">Real marketplace listings</h2>
               <p className="text-sm text-muted-foreground leading-relaxed mb-4">
-                Every trade-up on TradeUpBot is built from actual, currently-listed skins on three marketplaces:
-                CSFloat, DMarket, and Skinport. No theoretical calculations, no idealized floats, no
-                average prices. Each input links to a specific listing you can purchase right now.
+                Every trade-up is built from skins currently listed on CSFloat, DMarket, and Skinport.
+                Each input links to a specific listing with its actual float and price, so the cost
+                you see is the cost you pay.
               </p>
               <div className="grid sm:grid-cols-3 gap-4">
                 <div className="border border-border rounded-lg p-4">
                   <div className="text-sm font-semibold mb-1">CSFloat</div>
-                  <p className="text-xs text-muted-foreground">Primary source for Covert skins and sale-based output pricing. Highest-confidence price data in the ecosystem.</p>
+                  <p className="text-xs text-muted-foreground">Primary source for Covert skins and sale-based output pricing. Sale history gives the most reliable price signal of the three sources.</p>
                 </div>
                 <div className="border border-border rounded-lg p-4">
                   <div className="text-sm font-semibold mb-1">DMarket</div>
@@ -53,15 +53,13 @@ export function FeaturesPage() {
             <section>
               <h2 className="text-xl font-bold mb-3">Outcome analysis with probability charts</h2>
               <p className="text-sm text-muted-foreground leading-relaxed mb-4">
-                Expand any trade-up to see every possible output skin, its probability, estimated value,
-                and whether it produces a profit or loss. The outcome distribution chart shows the full
-                picture at a glance — which outcomes are likely, which are valuable, and what your
-                downside looks like.
+                Expand any trade-up to see every possible output skin, its probability, its estimated
+                value, and its profit or loss. The distribution chart shows which outcomes are likely
+                and how deep the downside runs.
               </p>
               <p className="text-sm text-muted-foreground leading-relaxed">
-                Each outcome's value accounts for the output skin's float range, the exact output float
-                your inputs would produce, the resulting condition, and marketplace seller fees. No
-                surprises when you get your result.
+                Each outcome's value accounts for the exact output float your inputs would produce,
+                the resulting wear condition, and marketplace seller fees.
               </p>
             </section>
 
@@ -69,14 +67,13 @@ export function FeaturesPage() {
             <section>
               <h2 className="text-xl font-bold mb-3">Float-targeted discovery across 45+ targets</h2>
               <p className="text-sm text-muted-foreground leading-relaxed mb-4">
-                The discovery engine doesn't just test one float value and hope for the best. It evaluates
-                each input combination across 45+ float targets, densely clustered around condition boundaries
-                (Factory New/Minimal Wear at 0.07, Minimal Wear/Field-Tested at 0.15, etc.).
+                Each input combination is evaluated at 45+ float targets, clustered around condition
+                boundaries (Factory New/Minimal Wear at 0.07, Minimal Wear/Field-Tested at 0.15, and so on).
               </p>
               <p className="text-sm text-muted-foreground leading-relaxed">
-                This finds the exact crossing point where an output flips from one condition to another —
-                identifying opportunities that manual calculations and single-target tools miss entirely.
-                Swap optimization further improves existing trade-ups by testing replacement inputs each cycle.
+                That locates the crossing point where an output flips to a better condition, which
+                single-target calculators miss. Swap optimization retests replacement inputs on
+                existing trade-ups each cycle.
               </p>
             </section>
 
@@ -84,9 +81,9 @@ export function FeaturesPage() {
             <section>
               <h2 className="text-xl font-bold mb-3">Verify system</h2>
               <p className="text-sm text-muted-foreground leading-relaxed mb-4">
-                Before committing money, hit Verify to check every input listing in real time. Verify calls
-                each marketplace's API to confirm that listings still exist and at what price. The trade-up's
-                profit, cost, and EV update instantly based on current data.
+                Before spending money, hit Verify. It calls each marketplace's API to confirm every
+                input listing still exists and at what price. The trade-up's cost, profit, and EV
+                update from the response.
               </p>
               <div className="flex gap-6 text-sm">
                 <div>
@@ -100,9 +97,8 @@ export function FeaturesPage() {
             <section>
               <h2 className="text-xl font-bold mb-3">Claim system</h2>
               <p className="text-sm text-muted-foreground leading-relaxed mb-4">
-                Pro users can claim a trade-up to hide its listings from all other TradeUpBot users for
-                30 minutes. This gives you an uncontested window to purchase each input without worrying
-                about another user buying them first.
+                Pro users can claim a trade-up to hide its listings from all other TradeUpBot users
+                for 30 minutes. During that window, no other user can see or buy those inputs.
               </p>
               <div className="flex gap-6 text-sm flex-wrap">
                 <div>
@@ -124,8 +120,8 @@ export function FeaturesPage() {
             <section>
               <h2 className="text-xl font-bold mb-3">All rarity tiers covered</h2>
               <p className="text-sm text-muted-foreground leading-relaxed mb-4">
-                TradeUpBot discovers profitable trade-ups across every rarity tier in CS2, from
-                cheap Mil-Spec inputs to high-value Knife and Glove contracts.
+                TradeUpBot discovers trade-ups in every CS2 rarity tier, from Consumer inputs
+                costing cents to Knife and Glove contracts.
               </p>
               <div className="space-y-2">
                 {[
@@ -148,10 +144,10 @@ export function FeaturesPage() {
             <section>
               <h2 className="text-xl font-bold mb-3">Price intelligence from 3 data sources</h2>
               <p className="text-sm text-muted-foreground leading-relaxed mb-4">
-                Output pricing is CSFloat-primary — sale history from CSFloat is the highest-confidence
-                price data available. DMarket and Skinport listing data fill gaps when CSFloat has
-                no coverage for a particular skin or condition. Knife and glove output pricing uses a
-                KNN model trained on 120,000+ price observations for float-precise estimates.
+                Output pricing uses CSFloat sale history first. DMarket and Skinport listing data
+                fill gaps when CSFloat has no coverage for a skin or condition. Knife and glove
+                output pricing uses a KNN model trained on 120,000+ price observations for
+                float-precise estimates.
               </p>
               <p className="text-sm text-muted-foreground leading-relaxed">
                 Input pricing uses actual listing prices with marketplace-specific buyer fees applied:
@@ -165,10 +161,9 @@ export function FeaturesPage() {
             <section>
               <h2 className="text-xl font-bold mb-3">Collection browser with knife/glove pool info</h2>
               <p className="text-sm text-muted-foreground leading-relaxed mb-4">
-                Browse every CS2 collection with detailed information: which knife and glove finishes
-                are in each collection's pool, how many listings exist per rarity tier, and which
-                collections currently have profitable trade-ups. Filter by knife collections, glove
-                collections, or profitability to narrow your focus.
+                Browse every CS2 collection: which knife and glove finishes are in its pool, how many
+                listings exist per rarity tier, and which collections currently have profitable
+                trade-ups. Filter by knives, gloves, or profitability.
               </p>
             </section>
 
@@ -176,19 +171,18 @@ export function FeaturesPage() {
             <section>
               <h2 className="text-xl font-bold mb-3">Continuously updated</h2>
               <p className="text-sm text-muted-foreground leading-relaxed mb-4">
-                The discovery engine runs in approximately 20-minute cycles, scanning for new listings
-                and recalculating trade-ups each cycle. DMarket data is fetched continuously at 2
-                requests per second in a separate process. Skinport data streams in via a live WebSocket
-                connection. Between fresh discovery, swap optimization, and revival of stale trade-ups,
-                the data is always moving toward the current market state.
+                The discovery engine runs in roughly 20-minute cycles, scanning new listings and
+                recalculating trade-ups. DMarket is fetched continuously at 2 requests per second in
+                a separate process; Skinport streams in over a live WebSocket. Each cycle also runs
+                swap optimization on existing trade-ups and rebuilds ones whose listings sold.
               </p>
             </section>
           </div>
 
           {/* CTA */}
           <div className="mt-16 pt-10 border-t border-border text-center">
-            <h2 className="text-xl font-bold mb-3">Ready to find profitable trade-ups?</h2>
-            <p className="text-sm text-muted-foreground mb-6">Sign in with Steam to get started. Free tier available.</p>
+            <h2 className="text-xl font-bold mb-3">Start free</h2>
+            <p className="text-sm text-muted-foreground mb-6">Sign in with Steam. The free tier shows every trade-up on a 3-hour delay.</p>
             <a
               href={authHref("/trade-ups")}
               onClick={() => trackEvent("sign_up_start", { location: "features_cta" })}

--- a/src/pages/FeaturesPage.tsx
+++ b/src/pages/FeaturesPage.tsx
@@ -19,7 +19,7 @@ export function FeaturesPage() {
         <div className="mx-auto max-w-4xl px-6">
           <h1 className="text-3xl sm:text-4xl font-bold mb-2">Features</h1>
           <p className="text-muted-foreground mb-12 max-w-2xl">
-            How TradeUpBot finds, prices, and locks profitable CS2 trade-up contracts.
+            How TradeUpBot finds, prices, and verifies profitable CS2 trade-up contracts.
           </p>
 
           {/* Feature sections */}

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -70,7 +70,7 @@ const LandingPage = ({ user }: { user?: LandingUser | null }) => {
   return (
     <div className="min-h-screen bg-background text-foreground font-sans antialiased">
       <title>TradeUpBot — Find Profitable CS2 Trade-Ups from Real Listings</title>
-      <meta name="description" content="Real-time CS2 trade-up contract analyzer. Find profitable trade-ups across all rarity tiers using actual marketplace listings from CSFloat, DMarket, and Skinport." />
+      <meta name="description" content="Real-time CS2 trade-up contract analyzer. Find profitable trade-ups across all rarity tiers using actual marketplace listings from CSFloat, DMarket, Skinport, and Buff.market." />
       <link rel="canonical" href="https://tradeupbot.app/" />
       <meta property="og:title" content="TradeUpBot — Find Profitable CS2 Trade-Ups from Real Listings" />
       <meta property="og:description" content="Find profitable CS2 trade-ups built from real, buyable listings. Verify availability and claim before anyone else." />
@@ -100,7 +100,7 @@ const LandingPage = ({ user }: { user?: LandingUser | null }) => {
             "name": "TradeUpBot",
             "url": "https://tradeupbot.app",
             "logo": "https://tradeupbot.app/favicon.svg",
-            "description": "CS2 trade-up contract analysis platform using real marketplace data from CSFloat, DMarket, and Skinport."
+            "description": "CS2 trade-up contract analysis platform using real marketplace data from CSFloat, DMarket, Skinport, and Buff.market."
           }
         ]
       })}} />
@@ -124,7 +124,7 @@ const LandingPage = ({ user }: { user?: LandingUser | null }) => {
                 Most calculators price trade-ups with idealized floats and average prices. TradeUpBot builds each contract from listings currently for sale.
               </p>
               <p className="text-sm text-muted-foreground/70 mb-8 max-w-xl">
-                Every input links to a specific listing on CSFloat, DMarket, or Skinport, with its exact float and price. The output float is computed from your inputs, not estimated.
+                Every input links to a specific listing on CSFloat, DMarket, Skinport, or Buff.market, with its exact float and price. The output float is computed from your inputs, not estimated.
               </p>
               <div className="flex items-center gap-4">
                 {user ? (
@@ -177,7 +177,7 @@ const LandingPage = ({ user }: { user?: LandingUser | null }) => {
             <div className="grid sm:grid-cols-3 gap-6 text-left">
               <div className="border border-border rounded-lg p-5">
                 <div className="text-green-500 text-sm font-semibold mb-2">Real listings</div>
-                <p className="text-sm text-muted-foreground">Each input links to a live listing on CSFloat, DMarket, or Skinport.</p>
+                <p className="text-sm text-muted-foreground">Each input links to a live listing on CSFloat, DMarket, Skinport, or Buff.market.</p>
               </div>
               <div className="border border-border rounded-lg p-5">
                 <div className="text-green-500 text-sm font-semibold mb-2">Verify before buying</div>
@@ -185,7 +185,7 @@ const LandingPage = ({ user }: { user?: LandingUser | null }) => {
               </div>
               <div className="border border-border rounded-lg p-5">
                 <div className="text-green-500 text-sm font-semibold mb-2">Claim to lock</div>
-                <p className="text-sm text-muted-foreground">Pro users can claim a trade-up for 30 minutes, hiding its listings from other users while they buy.</p>
+                <p className="text-sm text-muted-foreground">Pro users can claim a trade-up for 30 minutes, hiding its listings from other TradeUpBot users while they buy.</p>
               </div>
             </div>
           </div>
@@ -234,9 +234,9 @@ const LandingPage = ({ user }: { user?: LandingUser | null }) => {
             <h2 className="text-2xl font-bold mb-10 text-center">How it works</h2>
             <div className="grid md:grid-cols-3 gap-8">
               {[
-                { n: "01", title: "Scan", desc: "Listings pulled from CSFloat, DMarket, and Skinport every cycle. Continuous DMarket coverage at 2 req/s." },
+                { n: "01", title: "Scan", desc: "Listings pulled from CSFloat, DMarket, Skinport, and Buff.market every cycle. Continuous DMarket coverage at 2 req/s." },
                 { n: "02", title: "Discover", desc: "Algorithms test thousands of input combinations at 45+ float targets. Swap optimization improves results each cycle." },
-                { n: "03", title: "Claim", desc: "Pro users see results instantly. Claim a trade-up to lock listings for 30 minutes while you buy." },
+                { n: "03", title: "Claim", desc: "Pro users see results instantly. Claim a trade-up to hide its listings from other TradeUpBot users for 30 minutes while you buy." },
               ].map((s, i) => (
                 <div key={i}>
                   <div className="text-xs text-muted-foreground/50 font-mono mb-2">{s.n}</div>
@@ -387,11 +387,11 @@ const LandingPage = ({ user }: { user?: LandingUser | null }) => {
             <h2 className="text-2xl font-bold mb-10 text-center">Frequently Asked Questions</h2>
             <div className="space-y-4">
               {[
-                { q: "How does TradeUpBot find profitable trade-ups?", a: "We continuously scan CSFloat, DMarket, and Skinport for real listings, then test thousands of input combinations across 45+ float targets. Every result is built only from listings currently for sale." },
+                { q: "How does TradeUpBot find profitable trade-ups?", a: "We continuously scan CSFloat, DMarket, Skinport, and Buff.market for real listings, then test thousands of input combinations across 45+ float targets. Every result is built only from listings currently for sale." },
                 { q: "How accurate are the prices?", a: "Prices come from real marketplace data: CSFloat sale history (primary), DMarket listing floors, and Skinport prices. All prices are estimates — actual prices may differ at time of purchase, especially after trade lock periods." },
                 { q: "Can I lose money on a trade-up?", a: "Yes. All prices are estimates based on current market data. Items purchased from marketplaces have trade lock periods during which prices can change. \"Profitable\" means profitable at current estimated prices, not guaranteed profit." },
-                { q: "What does Verify do?", a: "Verify checks whether every input listing still exists on its marketplace and at what price. The trade-up's cost, profit, and EV update from the response." },
-                { q: "What does Claim do?", a: "Pro users can claim a trade-up to lock its listings for 30 minutes. While claimed, those listings are hidden from other users so no one can buy them while you're purchasing." },
+                { q: "What does Verify do?", a: "Verify checks whether every input listing still exists on its marketplace and at what price. The trade-up's cost, profit, and ROI update from the response." },
+                { q: "What does Claim do?", a: "Pro users can claim a trade-up to hide its listings from other TradeUpBot users for 30 minutes while they buy. Buyers on the marketplaces themselves can still purchase the inputs — a claim removes TradeUpBot competition, it doesn't reserve listings." },
               ].map((item, i) => (
                 <details key={i} className="group border border-border rounded-lg">
                   <summary className="flex items-center justify-between cursor-pointer px-5 py-4 text-sm font-medium select-none">

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -121,10 +121,10 @@ const LandingPage = ({ user }: { user?: LandingUser | null }) => {
                 CS2 trade-ups built from<br />real, buyable listings
               </h1>
               <p className="text-lg text-muted-foreground mb-4 max-w-xl">
-                Other tools show theoretical trade-ups with idealized floats and average prices. We build contracts from actual marketplace listings you can buy right now.
+                Most calculators price trade-ups with idealized floats and average prices. TradeUpBot builds each contract from listings currently for sale.
               </p>
               <p className="text-sm text-muted-foreground/70 mb-8 max-w-xl">
-                Every trade-up on TradeUpBot links to specific listings on CSFloat, DMarket, and Skinport — with exact floats, exact prices, and deterministic outcomes. No guesswork.
+                Every input links to a specific listing on CSFloat, DMarket, or Skinport, with its exact float and price. The output float is computed from your inputs, not estimated.
               </p>
               <div className="flex items-center gap-4">
                 {user ? (
@@ -172,20 +172,20 @@ const LandingPage = ({ user }: { user?: LandingUser | null }) => {
           <div className="mx-auto max-w-4xl px-6 text-center">
             <h2 className="text-3xl sm:text-4xl font-bold mb-4">What you see is what you pay</h2>
             <p className="text-lg text-muted-foreground mb-10 max-w-2xl mx-auto">
-              Every trade-up on TradeUpBot is built from real marketplace listings — not theoretical calculations with idealized floats. Click any input to buy it directly.
+              Costs come from live listings, not price averages. Click any input to open the listing and buy it.
             </p>
             <div className="grid sm:grid-cols-3 gap-6 text-left">
               <div className="border border-border rounded-lg p-5">
                 <div className="text-green-500 text-sm font-semibold mb-2">Real listings</div>
-                <p className="text-sm text-muted-foreground">Every input links to an actual listing on CSFloat, DMarket, or Skinport that you can purchase right now.</p>
+                <p className="text-sm text-muted-foreground">Each input links to a live listing on CSFloat, DMarket, or Skinport.</p>
               </div>
               <div className="border border-border rounded-lg p-5">
                 <div className="text-green-500 text-sm font-semibold mb-2">Verify before buying</div>
-                <p className="text-sm text-muted-foreground">One-click verification checks if all inputs are still listed and at what price. No surprises at checkout.</p>
+                <p className="text-sm text-muted-foreground">Verify re-checks every input against the marketplace: still listed, and at what price. Stats update before you spend.</p>
               </div>
               <div className="border border-border rounded-lg p-5">
                 <div className="text-green-500 text-sm font-semibold mb-2">Claim to lock</div>
-                <p className="text-sm text-muted-foreground">Pro users can claim a trade-up for 30 minutes, hiding the listings from other users while you buy.</p>
+                <p className="text-sm text-muted-foreground">Pro users can claim a trade-up for 30 minutes, hiding its listings from other users while they buy.</p>
               </div>
             </div>
           </div>
@@ -197,7 +197,7 @@ const LandingPage = ({ user }: { user?: LandingUser | null }) => {
             <div className="grid md:grid-cols-2 gap-12 mb-20">
               <div>
                 <h2 className="text-2xl font-bold mb-3">Outcome analysis</h2>
-                <p className="text-muted-foreground mb-6">Every possible outcome with probabilities, expected value, and the exact inputs needed. Claim to lock listings for 30 minutes while you buy.</p>
+                <p className="text-muted-foreground mb-6">Every possible outcome with its probability, value after seller fees, and the exact inputs to buy.</p>
                 <picture>
                   <source type="image/webp" srcSet="/expanded-375w.webp 375w, /expanded-768w.webp 768w, /expanded-1280w.webp 1280w" sizes="(max-width: 768px) 100vw, 50vw" />
                   <img src="/expanded-1280w.jpg" srcSet="/expanded-375w.jpg 375w, /expanded-768w.jpg 768w, /expanded-1280w.jpg 1280w" sizes="(max-width: 768px) 100vw, 50vw" alt="Trade-up outcomes" width="2596" height="1822" loading="lazy" className="rounded-lg border border-border w-full" />
@@ -363,7 +363,7 @@ const LandingPage = ({ user }: { user?: LandingUser | null }) => {
         <section id="blog" className="py-20 border-t border-border">
           <div className="mx-auto max-w-4xl px-6">
             <h2 className="text-2xl font-bold mb-3 text-center">Blog</h2>
-            <p className="text-muted-foreground text-center mb-10">Guides, strategies, and updates from the TradeUpBot team.</p>
+            <p className="text-muted-foreground text-center mb-10">Trade-up guides, float mechanics, and platform updates.</p>
             <div className="grid sm:grid-cols-3 gap-6">
               {blogMeta.slice(0, 3).map((post) => (
                 <a key={post.slug} href={`/blog/${post.slug}/`} className="border border-border rounded-lg p-5 hover:border-foreground/20 transition-colors block">
@@ -387,10 +387,10 @@ const LandingPage = ({ user }: { user?: LandingUser | null }) => {
             <h2 className="text-2xl font-bold mb-10 text-center">Frequently Asked Questions</h2>
             <div className="space-y-4">
               {[
-                { q: "How does TradeUpBot find profitable trade-ups?", a: "We continuously scan CSFloat, DMarket, and Skinport for real listings, then test thousands of input combinations across 45+ float targets. Every trade-up is built from actual buyable listings — not theoretical calculations." },
+                { q: "How does TradeUpBot find profitable trade-ups?", a: "We continuously scan CSFloat, DMarket, and Skinport for real listings, then test thousands of input combinations across 45+ float targets. Every result is built only from listings currently for sale." },
                 { q: "How accurate are the prices?", a: "Prices come from real marketplace data: CSFloat sale history (primary), DMarket listing floors, and Skinport prices. All prices are estimates — actual prices may differ at time of purchase, especially after trade lock periods." },
                 { q: "Can I lose money on a trade-up?", a: "Yes. All prices are estimates based on current market data. Items purchased from marketplaces have trade lock periods during which prices can change. \"Profitable\" means profitable at current estimated prices, not guaranteed profit." },
-                { q: "What does Verify do?", a: "Verify checks if all input listings still exist on the marketplace and at what price. It updates the trade-up stats in real time so you know exactly what you're buying before you commit." },
+                { q: "What does Verify do?", a: "Verify checks whether every input listing still exists on its marketplace and at what price. The trade-up's cost, profit, and EV update from the response." },
                 { q: "What does Claim do?", a: "Pro users can claim a trade-up to lock its listings for 30 minutes. While claimed, those listings are hidden from other users so no one can buy them while you're purchasing." },
               ].map((item, i) => (
                 <details key={i} className="group border border-border rounded-lg">

--- a/src/pages/ListingSniperPage.tsx
+++ b/src/pages/ListingSniperPage.tsx
@@ -428,7 +428,7 @@ export function ListingSniperPage() {
           <div className="text-4xl mb-3 opacity-50">&#x1F3AF;</div>
           <p className="mb-2">No underpriced listings found.</p>
           <p className="text-sm text-muted-foreground/70">
-            Try adjusting filters, or the KNN model may not have sufficient data for the selected skins.
+            Widen the filters or lower the min diff. Skins without enough sale data have no price estimate and never appear here.
           </p>
         </div>
       ) : (

--- a/src/pages/MyTradeUpsPage.tsx
+++ b/src/pages/MyTradeUpsPage.tsx
@@ -90,15 +90,21 @@ export default function MyTradeUpsPage() {
       const mainReq = activeTab === "claims"
         ? fetch("/api/trade-ups?my_claims=true&per_page=50", { credentials: "include", signal })
         : fetch(`/api/my-trade-ups?status=${activeTab === "purchased" ? "purchased" : "executed,sold"}`, { credentials: "include", signal });
-      const [res, statsRes] = await Promise.all([
-        mainReq,
-        fetch("/api/my-trade-ups/stats", { credentials: "include", signal }),
-      ]);
-      const [data, statsData] = await Promise.all([res.json(), statsRes.json()]);
+      // Start stats in parallel, but never let its failure block the table
+      const statsReq = fetch("/api/my-trade-ups/stats", { credentials: "include", signal })
+        .then((r) => r.json())
+        .then((statsData: UserTradeUpStats) => {
+          if (!signal?.aborted) setStats(statsData);
+        })
+        .catch((e) => {
+          if (!signal?.aborted) console.error("Failed to fetch trade-up stats", e);
+        });
+      const res = await mainReq;
+      const data = await res.json();
       if (signal?.aborted) return;
       if (activeTab === "claims") setClaimTradeUps(data.trade_ups || []);
       else setEntries(data.trade_ups || []);
-      setStats(statsData);
+      await statsReq;
     } catch (e) {
       if (signal?.aborted) return;
       console.error("Failed to fetch my trade-ups", e);

--- a/src/pages/MyTradeUpsPage.tsx
+++ b/src/pages/MyTradeUpsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { Button } from "@shared/components/ui/button.js";
 import { TradeUpTable } from "../components/TradeUpTable.js";
 import type { TradeUp, TradeUpInput, TradeUpOutcome, Condition } from "../../shared/types.js";
@@ -84,32 +84,33 @@ export default function MyTradeUpsPage() {
   const [salePrice, setSalePrice] = useState("");
   const [saleMarketplace, setSaleMarketplace] = useState("csfloat");
 
-  const fetchData = useCallback(async () => {
+  const fetchData = useCallback(async (signal?: AbortSignal) => {
     setLoading(true);
     try {
-      if (activeTab === "claims") {
-        const res = await fetch("/api/trade-ups?my_claims=true&per_page=50", { credentials: "include" });
-        const data = await res.json();
-        setClaimTradeUps(data.trade_ups || []);
-      } else {
-        const statusParam = activeTab === "purchased" ? "purchased" : "executed,sold";
-        const res = await fetch(`/api/my-trade-ups?status=${statusParam}`, { credentials: "include" });
-        const data = await res.json();
-        setEntries(data.trade_ups || []);
-      }
-
-      const statsRes = await fetch("/api/my-trade-ups/stats", { credentials: "include" });
-      const statsData = await statsRes.json();
+      const mainReq = activeTab === "claims"
+        ? fetch("/api/trade-ups?my_claims=true&per_page=50", { credentials: "include", signal })
+        : fetch(`/api/my-trade-ups?status=${activeTab === "purchased" ? "purchased" : "executed,sold"}`, { credentials: "include", signal });
+      const [res, statsRes] = await Promise.all([
+        mainReq,
+        fetch("/api/my-trade-ups/stats", { credentials: "include", signal }),
+      ]);
+      const [data, statsData] = await Promise.all([res.json(), statsRes.json()]);
+      if (signal?.aborted) return;
+      if (activeTab === "claims") setClaimTradeUps(data.trade_ups || []);
+      else setEntries(data.trade_ups || []);
       setStats(statsData);
     } catch (e) {
+      if (signal?.aborted) return;
       console.error("Failed to fetch my trade-ups", e);
     } finally {
-      setLoading(false);
+      if (!signal?.aborted) setLoading(false);
     }
   }, [activeTab]);
 
   useEffect(() => {
-    fetchData();
+    const controller = new AbortController();
+    fetchData(controller.signal);
+    return () => controller.abort();
   }, [fetchData]);
 
   // Action handlers
@@ -189,10 +190,11 @@ export default function MyTradeUpsPage() {
     }
   };
 
-  // Map entries for table display
-  const mappedTradeUps = entries.map(userTradeUpToTradeUp);
+  // Map entries for table display (memoized: a fresh array every render would
+  // retrigger TradeUpTable's claim-state reset effect on each parent render)
+  const mappedTradeUps = useMemo(() => entries.map(userTradeUpToTradeUp), [entries]);
   // Keep a lookup from TradeUp.id → UserTradeUp for action bar rendering
-  const entryById = new Map(entries.map(e => [e.id, e]));
+  const entryById = useMemo(() => new Map(entries.map(e => [e.id, e])), [entries]);
 
   // Purchased tab action bar
   const renderPurchasedActions = useCallback((tu: TradeUp) => {

--- a/src/pages/PricingPage.tsx
+++ b/src/pages/PricingPage.tsx
@@ -241,23 +241,23 @@ export function PricingPage() {
 
             <PricingFaqItem question="Is there a free trial for Pro?">
               <p>
-                No separate trial. The Free tier has no time limit: same trade-ups, full filters
-                and listing links, on a 3-hour delay. Upgrade when you want real-time data,
+                No separate trial. The Free tier has no time limit: full filters and listing
+                links, with trade-up data delayed 3 hours. Upgrade when you want real-time data,
                 verification, and claims.
               </p>
             </PricingFaqItem>
 
             <PricingFaqItem question="What do the data delays mean?">
               <p>
-                Free users see trade-ups 3 hours after discovery. Pro users see them immediately.
-                On a 3-hour delay, the best listings are often already bought.
+                Free users see trade-up data delayed 3 hours — contracts whose inputs sell in the
+                meantime drop out. Pro users see everything immediately, before the best listings get bought.
               </p>
             </PricingFaqItem>
 
             <PricingFaqItem question="Do claims reserve listings on the marketplace?">
               <p>
                 No. Claims only hide trade-up listings from other TradeUpBot users. Other buyers on
-                CSFloat, DMarket, or Skinport who aren't using TradeUpBot can still purchase the listings.
+                CSFloat, DMarket, Skinport, or Buff.market who aren't using TradeUpBot can still purchase the listings.
                 Claims reduce your competition, but don't guarantee availability.
               </p>
             </PricingFaqItem>

--- a/src/pages/PricingPage.tsx
+++ b/src/pages/PricingPage.tsx
@@ -92,7 +92,7 @@ export function PricingPage() {
         <div className="mx-auto max-w-4xl px-6">
           <h1 className="text-3xl sm:text-4xl font-bold mb-2 text-center">Pricing</h1>
           <p className="text-muted-foreground mb-12 text-center">
-            Start free. Upgrade when you're ready to act on opportunities.
+            Start free. Upgrade when the 3-hour delay costs you trade-ups.
           </p>
 
           {/* Billing interval toggle */}
@@ -234,23 +234,23 @@ export function PricingPage() {
 
             <PricingFaqItem question="What payment methods are accepted?">
               <p>
-                We accept all major credit and debit cards (Visa, Mastercard, American Express) through
-                Stripe. All payments are processed securely — we never see or store your card details.
+                All major credit and debit cards (Visa, Mastercard, American Express) through
+                Stripe. Card details never touch our servers.
               </p>
             </PricingFaqItem>
 
             <PricingFaqItem question="Is there a free trial for Pro?">
               <p>
-                There's no separate trial — the Free tier itself serves as a permanent trial. You can
-                use the Free tier for as long as you want to explore the platform. When you're ready
-                to act on trade-ups with real-time data, upgrade to Pro.
+                No separate trial. The Free tier has no time limit: same trade-ups, full filters
+                and listing links, on a 3-hour delay. Upgrade when you want real-time data,
+                verification, and claims.
               </p>
             </PricingFaqItem>
 
             <PricingFaqItem question="What do the data delays mean?">
               <p>
-                Free users see trade-ups 3 hours after they're discovered. Pro users see them immediately.
-                Shorter delays mean you can act on opportunities before other users see them.
+                Free users see trade-ups 3 hours after discovery. Pro users see them immediately.
+                On a 3-hour delay, the best listings are often already bought.
               </p>
             </PricingFaqItem>
 

--- a/src/pages/SkinPage.tsx
+++ b/src/pages/SkinPage.tsx
@@ -12,13 +12,17 @@ export function SkinPage() {
 
   useEffect(() => {
     if (!slug) return;
+    let cancelled = false;
+    setSkinName(null);
+    setNotFound(false);
     fetch(`/api/skin-by-slug/${encodeURIComponent(slug)}`)
       .then(r => {
-        if (!r.ok) { setNotFound(true); return null; }
+        if (!r.ok) { if (!cancelled) setNotFound(true); return null; }
         return r.json();
       })
-      .then(data => { if (data?.name) setSkinName(data.name); })
-      .catch(() => setNotFound(true));
+      .then(data => { if (!cancelled && data?.name) setSkinName(data.name); })
+      .catch(() => { if (!cancelled) setNotFound(true); });
+    return () => { cancelled = true; };
   }, [slug]);
 
   if (notFound) {

--- a/src/pages/TradeUpSharePage.tsx
+++ b/src/pages/TradeUpSharePage.tsx
@@ -47,13 +47,16 @@ export function TradeUpSharePage() {
 
   useEffect(() => {
     if (!id) return;
+    let cancelled = false;
     setLoading(true);
+    setError(null);
     fetch(`/api/trade-ups/${id}`)
       .then(r => {
         if (!r.ok) throw new Error(r.status === 404 ? "Trade-up not found" : "Failed to load");
         return r.json();
       })
       .then(data => {
+        if (cancelled) return;
         const outcomes = data.outcomes || (data.outcomes_json ? JSON.parse(data.outcomes_json) : []);
         setTu({
           id: data.id,
@@ -81,8 +84,9 @@ export function TradeUpSharePage() {
         });
         trackEvent("tradeup_view", { tradeup_id: String(data.id) });
       })
-      .catch(err => setError(err.message))
-      .finally(() => setLoading(false));
+      .catch(err => { if (!cancelled) setError(err.message); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
   }, [id]);
 
   const handleCopy = () => {

--- a/src/pages/TradeUpsPage.tsx
+++ b/src/pages/TradeUpsPage.tsx
@@ -85,6 +85,11 @@ export function TradeUpsPage({ types, defaultType, status, refreshKey, onNavigat
     return f;
   });
   const debouncedFilters = useDebouncedValue(filters, 300);
+  // Referential equality: true on mount and once the debounce settles. While false,
+  // the fetch effect is gated — otherwise a synchronous page/type change during the
+  // 300ms window would fire a request with the PREVIOUS filters and commit stale
+  // results over controls that already show the new ones.
+  const filtersSettled = filters === debouncedFilters;
 
   const isFree = tier === "free";
 
@@ -151,9 +156,10 @@ export function TradeUpsPage({ types, defaultType, status, refreshKey, onNavigat
   }, [sort, order, page, perPage, debouncedFilters, type, includeStale, refreshKey]);
 
   useEffect(() => {
+    if (!filtersSettled) return; // reruns when the debounce settles
     fetchTradeUps();
     return () => { if (abortRef.current) abortRef.current.abort(); };
-  }, [fetchTradeUps]);
+  }, [fetchTradeUps, filtersSettled]);
 
   const handleSort = (column: string) => {
     if (sort === column) {
@@ -180,7 +186,7 @@ export function TradeUpsPage({ types, defaultType, status, refreshKey, onNavigat
     <>
       <h1 className="sr-only">Profitable CS2 Trade-Up Contracts</h1>
       <title>Profitable CS2 Trade-Ups — Live Contracts from Real Listings | TradeUpBot</title>
-      <meta name="description" content="Browse profitable CS2 (formerly CS:GO) trade-up contracts from real marketplace listings. Filter by profit, ROI, cost, and rarity. Data from CSFloat, DMarket, and Skinport." />
+      <meta name="description" content="Browse profitable CS2 (formerly CS:GO) trade-up contracts from real marketplace listings. Filter by profit, ROI, cost, and rarity. Data from CSFloat, DMarket, Skinport, and Buff.market." />
       <link rel="canonical" href="https://tradeupbot.app/trade-ups" />
       <meta property="og:title" content="Profitable CS2 Trade-Ups — Live Contracts | TradeUpBot" />
       <meta property="og:description" content="Browse profitable CS2 trade-up contracts from real marketplace listings. Filter by profit, ROI, cost, and rarity." />
@@ -207,7 +213,7 @@ export function TradeUpsPage({ types, defaultType, status, refreshKey, onNavigat
           {
             "@type": "Question",
             "name": "How does TradeUpBot find profitable trade-ups?",
-            "acceptedAnswer": { "@type": "Answer", "text": "TradeUpBot scans real marketplace listings across CSFloat, DMarket, and Skinport. For each valid combination of 10 inputs, it calculates expected output value using the actual float formula and accounts for marketplace fees on both the buy and sell sides." }
+            "acceptedAnswer": { "@type": "Answer", "text": "TradeUpBot scans real marketplace listings across CSFloat, DMarket, Skinport, and Buff.market. For each valid combination of 10 inputs, it calculates expected output value using the actual float formula and accounts for marketplace fees on both the buy and sell sides." }
           },
           {
             "@type": "Question",
@@ -220,7 +226,7 @@ export function TradeUpsPage({ types, defaultType, status, refreshKey, onNavigat
       <section className="mb-5">
         <h2 className="text-base font-semibold mb-1.5">Find Profitable CS2 Trade-Up Contracts</h2>
         <p className="text-sm text-muted-foreground leading-relaxed">
-          Every contract below is built from real, buyable listings on CSFloat, DMarket, and Skinport, with marketplace fees on both sides already priced in. Filter by profit, ROI, cost, or outcome odds across every rarity tier — Knife, Glove, Covert, Classified, Restricted, Mil-Spec.
+          Every contract below is built from real, buyable listings on CSFloat, DMarket, Skinport, and Buff.market, with marketplace fees on both sides already priced in. Filter by profit, ROI, cost, or outcome odds across every rarity tier — Knife, Glove, Covert, Classified, Restricted, Mil-Spec.
         </p>
       </section>
 
@@ -345,7 +351,7 @@ export function TradeUpsPage({ types, defaultType, status, refreshKey, onNavigat
           </div>
           <div>
             <h3 className="text-sm font-medium mb-1">How does TradeUpBot find profitable trade-ups?</h3>
-            <p className="text-sm text-muted-foreground leading-relaxed">TradeUpBot scans real marketplace listings across CSFloat, DMarket, and Skinport. For each valid combination of 10 inputs, it calculates the expected output value using the actual CS2 float formula and accounts for marketplace fees on both the buy and sell sides — only surfaces contracts where the numbers work.</p>
+            <p className="text-sm text-muted-foreground leading-relaxed">TradeUpBot scans real marketplace listings across CSFloat, DMarket, Skinport, and Buff.market. For each valid combination of 10 inputs, it calculates the expected output value using the actual CS2 float formula and accounts for marketplace fees on both the buy and sell sides — only surfaces contracts where the numbers work.</p>
           </div>
           <div>
             <h3 className="text-sm font-medium mb-1">Are these listings live?</h3>

--- a/src/pages/TradeUpsPage.tsx
+++ b/src/pages/TradeUpsPage.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useSearchParams } from "react-router-dom";
-import type { TradeUp, TradeUpListResponse, SyncStatus } from "../../shared/types.js";
+import type { TradeUp, SyncStatus } from "../../shared/types.js";
 import { TradeUpTable } from "../components/TradeUpTable.js";
 import { FilterBar, FilterChips, EMPTY_FILTERS, filtersToParams } from "../components/FilterBar.js";
 import type { Filters } from "../components/FilterBar.js";
 import { Button } from "@shared/components/ui/button.js";
 import { ProductCTA } from "../components/ProductCTA.js";
+import { useDebouncedValue } from "../hooks/useDebouncedValue.js";
 type TradeUpType = "all" | "covert_knife" | "classified_covert" | "restricted_classified" | "milspec_restricted" | "industrial_milspec" | "consumer_industrial";
 
 interface TypeOption {
@@ -22,6 +23,11 @@ interface Props {
   onNavigateSkin: (skinName: string) => void;
   onNavigateCollection: (name: string) => void;
 }
+
+// URL params this page owns; anything else (e.g. ref= attribution) is preserved on sync.
+const OWNED_PARAMS = ["skin", "collection", "min_profit", "max_profit", "min_roi", "max_roi",
+  "min_cost", "max_cost", "min_chance", "max_chance", "max_loss", "min_win", "markets",
+  "sort", "order", "page", "stale", "type"];
 
 function UpgradeBanner({ message }: { message: string }) {
   return (
@@ -78,26 +84,28 @@ export function TradeUpsPage({ types, defaultType, status, refreshKey, onNavigat
     if (marketsParam) f.markets = marketsParam.split(",");
     return f;
   });
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const debouncedFilters = useDebouncedValue(filters, 300);
 
   const isFree = tier === "free";
-  const isPro = tier === "pro" || tier === "admin";
 
-  // Sync state to URL search params
+  // Sync state to URL search params without clobbering params owned by other features
   useEffect(() => {
-    const params = filtersToParams(filters);
-    if (sort !== "trade_up_score") params.set("sort", sort);
-    if (order !== "desc") params.set("order", order);
-    if (page > 1) params.set("page", String(page));
-    if (includeStale) params.set("stale", "true");
-    if (type !== types[0]?.value) params.set("type", type);
-    setSearchParams(params, { replace: true });
+    setSearchParams(prev => {
+      const params = new URLSearchParams(prev);
+      for (const key of OWNED_PARAMS) params.delete(key);
+      for (const [key, value] of filtersToParams(filters)) params.set(key, value);
+      if (sort !== "trade_up_score") params.set("sort", sort);
+      if (order !== "desc") params.set("order", order);
+      if (page > 1) params.set("page", String(page));
+      if (includeStale) params.set("stale", "true");
+      if (type !== types[0]?.value) params.set("type", type);
+      return params;
+    }, { replace: true });
   }, [sort, order, page, includeStale, filters, type, setSearchParams, types]);
 
   const handleFiltersChange = useCallback((f: Filters) => {
-    setFilters(f);
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => setPage(1), 300);
+    setFilters(f); // controlled inputs update immediately
+    setPage(1); // reset synchronously; the fetch waits on debouncedFilters
   }, []);
 
   // Cancel in-flight requests when sort/filter/type changes
@@ -111,7 +119,7 @@ export function TradeUpsPage({ types, defaultType, status, refreshKey, onNavigat
 
     if (!silent) setLoading(true);
     try {
-      const params = filtersToParams(filters);
+      const params = filtersToParams(debouncedFilters);
       params.set("sort", sort);
       params.set("order", order);
       params.set("page", String(page));
@@ -140,7 +148,7 @@ export function TradeUpsPage({ types, defaultType, status, refreshKey, onNavigat
     } finally {
       if (!controller.signal.aborted && !silent) setLoading(false);
     }
-  }, [sort, order, page, perPage, filters, type, includeStale, refreshKey]);
+  }, [sort, order, page, perPage, debouncedFilters, type, includeStale, refreshKey]);
 
   useEffect(() => {
     fetchTradeUps();
@@ -157,8 +165,6 @@ export function TradeUpsPage({ types, defaultType, status, refreshKey, onNavigat
     setPage(1);
   };
 
-  // Server handles sorting for all tiers now
-  const sortedTradeUps = tradeUps;
 
   const handleTypeChange = (newType: TradeUpType) => {
     // Batch state updates: set loading with type change so old data
@@ -167,10 +173,6 @@ export function TradeUpsPage({ types, defaultType, status, refreshKey, onNavigat
     setPage(1);
     setLoading(true);
   };
-
-  const handleClaimChange = useCallback((delta: number) => {
-    // no-op tracking; claims page is now separate
-  }, []);
 
   const totalPages = Math.ceil(total / perPage);
 
@@ -218,7 +220,7 @@ export function TradeUpsPage({ types, defaultType, status, refreshKey, onNavigat
       <section className="mb-5">
         <h2 className="text-base font-semibold mb-1.5">Find Profitable CS2 Trade-Up Contracts</h2>
         <p className="text-sm text-muted-foreground leading-relaxed">
-          Browse profitable CS2 trade-up contracts built from real, buyable listings across all rarity tiers — Knife, Glove, Covert, Classified, Restricted, Mil-Spec. Every entry uses live pricing from CSFloat, DMarket, and Skinport with marketplace fees already factored in.
+          Every contract below is built from real, buyable listings on CSFloat, DMarket, and Skinport, with marketplace fees on both sides already priced in. Filter by profit, ROI, cost, or outcome odds across every rarity tier — Knife, Glove, Covert, Classified, Restricted, Mil-Spec.
         </p>
       </section>
 
@@ -250,7 +252,7 @@ export function TradeUpsPage({ types, defaultType, status, refreshKey, onNavigat
           <div className="flex-1 min-w-0">
             <FilterBar filters={filters} onFiltersChange={handleFiltersChange} />
           </div>
-          <label className="flex items-center gap-1.5 text-sm text-muted-foreground cursor-pointer select-none whitespace-nowrap shrink-0" title="Show trade-ups with missing input listings (sold/delisted)">
+          <label className="flex items-center gap-1.5 text-sm text-muted-foreground cursor-pointer select-none whitespace-nowrap shrink-0" title="Include trade-ups whose input listings have sold or been delisted since discovery">
             <input
               type="checkbox"
               checked={includeStale}
@@ -279,33 +281,32 @@ export function TradeUpsPage({ types, defaultType, status, refreshKey, onNavigat
           {status?.daemon_status?.phase === "calculating" ? (
             <>
               <div className="text-4xl mb-3 opacity-50">&#9881;</div>
-              <p className="mb-2">Calculating trade-ups...</p>
+              <p className="mb-2">Calculating trade-ups from current listings...</p>
               <p className="text-sm text-muted-foreground/70">{status.daemon_status.detail}</p>
             </>
           ) : status?.daemon_status?.phase === "fetching" ? (
             <>
               <div className="text-4xl mb-3 opacity-50">&#8635;</div>
-              <p className="mb-2">Fetching listing data from CSFloat...</p>
-              <p className="text-sm text-muted-foreground/70">Trade-ups will appear after the first calculation cycle.</p>
+              <p className="mb-2">Fetching listings from CSFloat...</p>
+              <p className="text-sm text-muted-foreground/70">Trade-ups appear after the first calculation cycle, usually within a few minutes.</p>
             </>
           ) : (
             <>
               <div className="text-4xl mb-3 opacity-50">&#128200;</div>
-              <p className="mb-2">No trade-ups match the current filters.</p>
-              <p className="text-sm text-muted-foreground/70">Try adjusting the filters above, or wait for the daemon to collect more data.</p>
+              <p className="mb-2">No trade-ups match these filters.</p>
+              <p className="text-sm text-muted-foreground/70">Widen a range, clear a filter, or check Show stale to include sold-out contracts.</p>
             </>
           )}
         </div>
       ) : (
         <div className={loading ? "opacity-50 pointer-events-none transition-opacity" : "transition-opacity"}>
           <TradeUpTable
-            tradeUps={sortedTradeUps}
+            tradeUps={tradeUps}
             sort={sort}
             order={order}
             onSort={handleSort}
             onNavigateSkin={onNavigateSkin}
             onNavigateCollection={onNavigateCollection}
-            onClaimChange={isPro ? handleClaimChange : undefined}
             tier={tier}
             claimLimit={claimLimit}
             verifyLimit={verifyLimit}

--- a/tests/integration/stale-leak.test.ts
+++ b/tests/integration/stale-leak.test.ts
@@ -29,15 +29,18 @@ describe("stale-leak coherence guard", () => {
     await ctx.cleanup();
   });
 
-  async function breakOneTradeUp(): Promise<number> {
-    // Pick a column-'active' trade-up and raw-delete one input listing,
-    // bypassing cascadeTradeUpStatuses — simulates the race.
+  /** Raw-delete input listings of a column-'active' trade-up, bypassing
+   *  cascadeTradeUpStatuses — simulates the race. `all` = delete every input
+   *  listing (canonical stale), else one (partial). Picks the HIGHEST id so
+   *  the row lands on page 1 (seed leaves trade_up_score NULL → order falls
+   *  back to id DESC). */
+  async function breakOneTradeUp(all = false): Promise<number> {
     const { rows: [tu] } = await ctx.pool.query(
-      `SELECT id FROM trade_ups WHERE listing_status = 'active' AND type = 'covert_knife' ORDER BY id LIMIT 1`
+      `SELECT id FROM trade_ups WHERE listing_status = 'active' AND type = 'covert_knife' ORDER BY id DESC LIMIT 1`
     );
     await ctx.pool.query(
-      `DELETE FROM listings WHERE id = (
-         SELECT listing_id FROM trade_up_inputs WHERE trade_up_id = $1 LIMIT 1
+      `DELETE FROM listings WHERE id IN (
+         SELECT listing_id FROM trade_up_inputs WHERE trade_up_id = $1 ${all ? "" : "LIMIT 1"}
        )`,
       [tu.id]
     );
@@ -95,5 +98,51 @@ describe("stale-leak coherence guard", () => {
     expect(broken).toBeDefined();
     expect(broken.listing_status).toBe("partial");
     expect(broken.missing_count).toBeGreaterThan(0);
+  });
+
+  it("heals ALL-inputs-missing to 'stale' and keeps it reachable via include_stale", async () => {
+    const brokenId = await breakOneTradeUp(true);
+
+    await request(ctx.app)
+      .get("/api/trade-ups?type=covert_knife")
+      .set("X-Test-User-Id", "user_pro")
+      .set("X-Test-User-Tier", "pro");
+
+    const { rows: [row] } = await ctx.pool.query(
+      `SELECT listing_status, preserved_at FROM trade_ups WHERE id = $1`,
+      [brokenId]
+    );
+    expect(row.listing_status).toBe("stale");
+    expect(row.preserved_at).not.toBeNull();
+
+    const res = await request(ctx.app)
+      .get("/api/trade-ups?type=covert_knife&include_stale=true")
+      .set("X-Test-User-Id", "user_pro")
+      .set("X-Test-User-Tier", "pro");
+    const broken = res.body.trade_ups.find((tu: { id: number }) => tu.id === brokenId);
+    expect(broken).toBeDefined();
+    expect(broken.listing_status).toBe("stale");
+  });
+
+  it("refills the page after healing so leaked rows don't leave holes", async () => {
+    // 6 already seeded + 50 more = 56 actives; per_page=50 → page 1 must stay
+    // full even when the top row leaks.
+    await seedTestData(ctx.pool, {
+      profitableCount: 50,
+      unprofitableCount: 0,
+      staleCount: 0,
+      type: "covert_knife",
+    });
+    const brokenId = await breakOneTradeUp();
+
+    const res = await request(ctx.app)
+      .get("/api/trade-ups?type=covert_knife&per_page=50")
+      .set("X-Test-User-Id", "user_pro")
+      .set("X-Test-User-Tier", "pro");
+
+    expect(res.status).toBe(200);
+    const ids = res.body.trade_ups.map((tu: { id: number }) => tu.id);
+    expect(ids).not.toContain(brokenId);
+    expect(ids.length).toBe(50);
   });
 });

--- a/tests/integration/stale-leak.test.ts
+++ b/tests/integration/stale-leak.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import request from "supertest";
+import { createTestApp, seedTestData, type TestContext } from "./setup.js";
+
+/**
+ * Coherence between the WHERE filter (listing_status column) and the canonical
+ * status recomputed from live listings.
+ *
+ * Bug: a listing deleted without cascadeTradeUpStatuses running (race, crashed
+ * fetcher, raw DELETE) leaves listing_status='active' in the column. The list
+ * endpoint's WHERE passes the row, then canonicalListingStatus() recomputes
+ * 'partial'/'stale' from the live LEFT JOIN — so the default view (Show stale
+ * OFF) renders yellow/red rows it promised to hide.
+ */
+describe("stale-leak coherence guard", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    ctx = await createTestApp({ defaultTier: "pro", defaultUserId: "user_pro" });
+    await seedTestData(ctx.pool, {
+      profitableCount: 6,
+      unprofitableCount: 0,
+      staleCount: 0,
+      type: "covert_knife",
+    });
+  });
+
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  async function breakOneTradeUp(): Promise<number> {
+    // Pick a column-'active' trade-up and raw-delete one input listing,
+    // bypassing cascadeTradeUpStatuses — simulates the race.
+    const { rows: [tu] } = await ctx.pool.query(
+      `SELECT id FROM trade_ups WHERE listing_status = 'active' AND type = 'covert_knife' ORDER BY id LIMIT 1`
+    );
+    await ctx.pool.query(
+      `DELETE FROM listings WHERE id = (
+         SELECT listing_id FROM trade_up_inputs WHERE trade_up_id = $1 LIMIT 1
+       )`,
+      [tu.id]
+    );
+    return tu.id;
+  }
+
+  it("default view (stale OFF) never returns rows with non-active canonical status", async () => {
+    const brokenId = await breakOneTradeUp();
+
+    const res = await request(ctx.app)
+      .get("/api/trade-ups?type=covert_knife")
+      .set("X-Test-User-Id", "user_pro")
+      .set("X-Test-User-Tier", "pro");
+
+    expect(res.status).toBe(200);
+    const returnedIds = res.body.trade_ups.map((tu: { id: number }) => tu.id);
+    expect(returnedIds).not.toContain(brokenId);
+    for (const tu of res.body.trade_ups) {
+      expect(tu.listing_status).toBe("active");
+    }
+  });
+
+  it("self-heals the listing_status column on read", async () => {
+    const brokenId = await breakOneTradeUp();
+
+    await request(ctx.app)
+      .get("/api/trade-ups?type=covert_knife")
+      .set("X-Test-User-Id", "user_pro")
+      .set("X-Test-User-Tier", "pro");
+
+    const { rows: [row] } = await ctx.pool.query(
+      `SELECT listing_status, preserved_at FROM trade_ups WHERE id = $1`,
+      [brokenId]
+    );
+    expect(row.listing_status).toBe("partial");
+    expect(row.preserved_at).not.toBeNull();
+  });
+
+  it("healed row stays visible under include_stale=true", async () => {
+    const brokenId = await breakOneTradeUp();
+
+    // First request drops + heals
+    await request(ctx.app)
+      .get("/api/trade-ups?type=covert_knife")
+      .set("X-Test-User-Id", "user_pro")
+      .set("X-Test-User-Tier", "pro");
+
+    const res = await request(ctx.app)
+      .get("/api/trade-ups?type=covert_knife&include_stale=true")
+      .set("X-Test-User-Id", "user_pro")
+      .set("X-Test-User-Tier", "pro");
+
+    expect(res.status).toBe(200);
+    const broken = res.body.trade_ups.find((tu: { id: number }) => tu.id === brokenId);
+    expect(broken).toBeDefined();
+    expect(broken.listing_status).toBe("partial");
+    expect(broken.missing_count).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/filter-bar.test.ts
+++ b/tests/unit/filter-bar.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import {
+  EMPTY_FILTERS,
+  filtersToParams,
+  hasActiveFilters,
+  type Filters,
+} from "../../src/components/FilterBar.js";
+
+// ─── filtersToParams ─────────────────────────────────────────────────────────
+
+describe("filtersToParams", () => {
+  it("returns no params for empty filters", () => {
+    expect(filtersToParams(EMPTY_FILTERS).toString()).toBe("");
+  });
+
+  it("converts dollar ranges to integer cents", () => {
+    const f: Filters = { ...EMPTY_FILTERS, minProfit: "1.5", maxProfit: "20" };
+    const p = filtersToParams(f);
+    expect(p.get("min_profit")).toBe("150");
+    expect(p.get("max_profit")).toBe("2000");
+  });
+
+  it("rounds fractional cents instead of truncating", () => {
+    // 0.29 * 100 === 28.999999999999996 in IEEE 754 — must round to 29
+    const p = filtersToParams({ ...EMPTY_FILTERS, minCost: "0.29" });
+    expect(p.get("min_cost")).toBe("29");
+  });
+
+  it("passes ROI and chance through unconverted", () => {
+    const f: Filters = { ...EMPTY_FILTERS, minRoi: "5", maxRoi: "50", minChance: "10", maxChance: "90" };
+    const p = filtersToParams(f);
+    expect(p.get("min_roi")).toBe("5");
+    expect(p.get("max_roi")).toBe("50");
+    expect(p.get("min_chance")).toBe("10");
+    expect(p.get("max_chance")).toBe("90");
+  });
+
+  it("converts maxLoss and minWin to cents", () => {
+    const p = filtersToParams({ ...EMPTY_FILTERS, maxLoss: "3", minWin: "100" });
+    expect(p.get("max_loss")).toBe("300");
+    expect(p.get("min_win")).toBe("10000");
+  });
+
+  it("joins skins with || and collections with |", () => {
+    const f: Filters = {
+      ...EMPTY_FILTERS,
+      skins: ["AK-47 | Redline", "M4A4 | 龍王 (Dragon King)"],
+      collections: ["The Phoenix Collection", "The Huntsman Collection"],
+    };
+    const p = filtersToParams(f);
+    expect(p.get("skin")).toBe("AK-47 | Redline||M4A4 | 龍王 (Dragon King)");
+    expect(p.get("collection")).toBe("The Phoenix Collection|The Huntsman Collection");
+  });
+
+  it("joins markets with commas", () => {
+    const p = filtersToParams({ ...EMPTY_FILTERS, markets: ["csfloat", "dmarket"] });
+    expect(p.get("markets")).toBe("csfloat,dmarket");
+  });
+
+  it("omits keys for empty strings and empty arrays", () => {
+    const p = filtersToParams({ ...EMPTY_FILTERS, minRoi: "5" });
+    expect([...p.keys()]).toEqual(["min_roi"]);
+  });
+});
+
+// ─── hasActiveFilters ────────────────────────────────────────────────────────
+
+describe("hasActiveFilters", () => {
+  it("is false for empty filters", () => {
+    expect(hasActiveFilters(EMPTY_FILTERS)).toBe(false);
+  });
+
+  it("is true when a market is selected", () => {
+    expect(hasActiveFilters({ ...EMPTY_FILTERS, markets: ["csfloat"] })).toBe(true);
+  });
+
+  it("is true when a skin or collection is selected", () => {
+    expect(hasActiveFilters({ ...EMPTY_FILTERS, skins: ["AK-47 | Redline"] })).toBe(true);
+    expect(hasActiveFilters({ ...EMPTY_FILTERS, collections: ["The Phoenix Collection"] })).toBe(true);
+  });
+
+  it("is true for each range field on its own", () => {
+    const rangeFields = [
+      "minProfit", "maxProfit", "minRoi", "maxRoi", "minCost", "maxCost",
+      "minChance", "maxChance", "maxLoss", "minWin",
+    ] as const;
+    for (const field of rangeFields) {
+      expect(hasActiveFilters({ ...EMPTY_FILTERS, [field]: "1" })).toBe(true);
+    }
+  });
+
+  it("is false again after clearing a range back to empty string", () => {
+    const f: Filters = { ...EMPTY_FILTERS, minProfit: "5" };
+    expect(hasActiveFilters({ ...f, minProfit: "" })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Bugs fixed
- **Duplicate clear affordance on filters**: active range/market filters rendered twice (blue pill + chip), each with its own clear; the in-dropdown Clear also had a stale-closure bug where clearing min+max via two sequential updates resurrected one value. Pills are now the single representation with an inline clear (sibling buttons, a11y-correct); chips remain only for skins/collections.
- **Partial/stale rows leaking into the default view**: the list WHERE trusted the `listing_status` column while the response recomputed live status from listings — rows whose listings vanished without a cascade (race/crashed fetcher) passed the filter and rendered yellow/red with 'Show stale' off. New coherence guard heals the column in a revalidating UPDATE, invalidates `tu:` cache, and requeries once so pages have no holes. Integration tests cover partial, all-missing→stale, include_stale reachability, and page refill.

## State/latency
- Debounced filter fetch (1 request per settled change), gated so page/type changes can't commit stale-filter results
- URL sync preserves non-owned params (`ref=` attribution survives)
- Abort-guarded fetches + stale-response sequencing across SkinPage, MyTradeUps, Calculator, CollectionViewer, SkinDetailPanel, useStatus
- TradeUpTable: keyed fragments, inflight-guarded expand fetches, immediate claim-timer tick

## Copy
- De-slopped landing/features/faq/pricing/sniper; factual corrections proven against code: Verify updates cost/profit/ROI (not EV), free tier = 3h-delayed data (not 'every trade-up'), claims hide inputs from TradeUpBot users only, Buff.market added as a source, partial/stale defined as unavailable (incl. claimed).

## Verification
- tsc clean, 775 unit tests green, integration failures identical to origin/main baseline (13 local-env Redis-dependent)
- Two adversarial review waves; wave-2 verdict: ship (all 7 wave-1 findings verified fixed)
- Browser QA on dev: pill clear, debounce (2 keystrokes → 1 fetch), stale toggle, leak heal, ref-param survival

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smoother, debounced filtering with clearer filter controls, quick clearing, and improved URL synchronization.
  * Expanded marketplace messaging and updated product, FAQ, pricing, and landing-page content.
  * Added clearer trade-up empty states and listing availability guidance.

* **Bug Fixes**
  * Improved cancellation and stale-response handling across searches, collection views, skin pages, and trade-up pages.
  * Trade-up listings now self-correct stale statuses and avoid displaying residual unavailable results.
  * Prevented duplicate detail requests and reset skin filters correctly when changing skins.

* **Tests**
  * Added coverage for filter behavior and stale trade-up listing protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->