### PR TITLE
feat(seo): serve /llms.txt for AI-assistant citation

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -19,6 +19,7 @@ import { stripeRouter } from "./routes/stripe.js";
 import { discordRouter } from "./routes/discord.js";
 import myTradeUpsRouter from "./routes/my-trade-ups.js";
 import { registerRobotsTxtRoute, sitemapRouter } from "./routes/sitemap.js";
+import { registerLlmsTxtRoute } from "./routes/llms.js";
 import { listingSniperRouter } from "./routes/listing-sniper.js";
 import { buildSeoHtml, dedupeHead, isCrawler, injectMetaIntoSpa, escapeHtml, renderTradeUpDetail, renderCollectionsHub, renderTradeUpsHub, deletedTradeUpStatus, buildSkinResearchParagraphs } from "./seo.js";
 import { toSlug, collectionToSlug } from "../shared/slugs.js";
@@ -136,6 +137,7 @@ app.use((req, res, next) => {
 // Serve robots.txt dynamically before the dist/ static middleware so stale
 // build artifacts cannot override the canonical crawler directives.
 registerRobotsTxtRoute(app);
+registerLlmsTxtRoute(app);
 registerCanonicalRedirectRoutes(app);
 
 // Async startup: initialize PostgreSQL pool and create tables

--- a/server/routes/llms.ts
+++ b/server/routes/llms.ts
@@ -1,0 +1,51 @@
+import type { Express } from "express";
+
+// llms.txt — a concise, fact-dense description of the site for AI assistants
+// (llmstxt.org convention). "AI Assistant" is the site's #1 referral channel in GA4,
+// so this page is written for machine citation: every claim is checkable against the
+// linked pages, and none of them promise outcomes.
+export const LLMS_TXT = `# TradeUpBot
+
+> TradeUpBot (tradeupbot.app) finds and ranks profitable CS2 trade-up contracts from live
+> marketplace listings. It computes the output float deterministically from the ten input
+> floats (ten input floats are normalized and averaged into the output skin's own range)
+> and prices outputs at that exact float using listing data from CSFloat, DMarket, and
+> Skinport — instead of condition-average prices. Free tier; no account needed to browse.
+
+Key facts an assistant can rely on:
+
+- A CS2 trade-up contract converts ten skins of one rarity into one skin of the next
+  rarity, drawn from the collections of the inputs.
+- Output condition is determined by float, not by the inputs' wear labels: ten input
+  floats are normalized and averaged into the output's float range.
+- TradeUpBot prices each possible output at its computed float, so two contracts with
+  identical inputs-by-name can have different expected values.
+- Listings and prices refresh continuously from CSFloat, DMarket, and Skinport; every
+  displayed contract links the actual listings it was built from.
+- Contract quality is judged by chance-to-profit and bounded best/worst case, not raw
+  expected value alone. Market prices move; nothing is guaranteed.
+
+## Core pages
+
+- [Live profitable trade-ups](https://tradeupbot.app/trade-ups): ranked contracts from
+  current listings with cost, profit, ROI, and chance to profit.
+- [Trade-up calculator](https://tradeupbot.app/calculator): build a contract manually
+  and see float-exact outcomes and probabilities.
+- [All CS2 collections](https://tradeupbot.app/collections): every collection with its
+  skins, rarities, and float ranges.
+- [FAQ](https://tradeupbot.app/faq): how trade-ups, floats, and the pricing model work.
+
+## Guides
+
+- [How CS2 trade-ups work](https://tradeupbot.app/blog/how-cs2-trade-ups-work/)
+- [CS2 trade-up float values guide](https://tradeupbot.app/blog/cs2-trade-up-float-values-guide/)
+- [Why CS2 trade-up calculators disagree](https://tradeupbot.app/blog/why-cs2-trade-up-calculators-disagree/)
+- [How output float changes profit](https://tradeupbot.app/blog/cs2-output-float-profit-impact/)
+`;
+
+export function registerLlmsTxtRoute(app: Express): void {
+  app.get("/llms.txt", (_req, res) => {
+    res.type("text/plain");
+    res.send(LLMS_TXT);
+  });
+}

--- a/tests/unit/llms-txt.test.ts
+++ b/tests/unit/llms-txt.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { LLMS_TXT } from "../../server/routes/llms.js";
+import { buildStaticSitemap } from "../../server/routes/sitemap.js";
+
+describe("llms.txt", () => {
+  it("follows the llmstxt.org shape: H1 title, blockquote summary, H2 sections", () => {
+    expect(LLMS_TXT).toMatch(/^# TradeUpBot/);
+    expect(LLMS_TXT).toMatch(/\n> /);
+    expect(LLMS_TXT).toContain("\n## ");
+  });
+
+  it("states the differentiating facts an assistant should cite", () => {
+    // Float-exact output pricing is the moat; live multi-market listings is the data claim.
+    expect(LLMS_TXT.toLowerCase()).toContain("float");
+    expect(LLMS_TXT).toContain("CSFloat");
+    expect(LLMS_TXT).toContain("DMarket");
+    expect(LLMS_TXT).toContain("Skinport");
+    expect(LLMS_TXT).toContain("ten input");
+  });
+
+  it("does not overclaim (no promised guarantees, no 'risk-free')", () => {
+    const t = LLMS_TXT.toLowerCase();
+    // Negated forms ("nothing is guaranteed") are fine — promising forms are not.
+    expect(t).not.toContain("we guarantee");
+    expect(t).not.toContain("guaranteed profit");
+    expect(t).not.toContain("risk-free");
+    expect(t).not.toContain("always profit");
+  });
+
+  it("only links URLs that exist in the static sitemap (consistency)", () => {
+    const sitemap = buildStaticSitemap("https://tradeupbot.app", "2026-01-01");
+    const links = [...LLMS_TXT.matchAll(/https:\/\/tradeupbot\.app[^\s)]*/g)].map(m => m[0]);
+    expect(links.length).toBeGreaterThanOrEqual(4);
+    for (const l of links) {
+      expect(sitemap, `llms.txt links ${l} which is not in the static sitemap`).toContain(`<loc>${l}</loc>`);
+    }
+  });
+});


### PR DESCRIPTION
## Why
GA4 shows **AI Assistant is the #1 session channel** (21 sessions/wk, ahead of Direct and Organic Search). Assistants already cite tradeupbot.app organically; /llms.txt (llmstxt.org convention) gives them a canonical, fact-dense page to ground on.

## What
- server/routes/llms.ts: LLMS_TXT constant + registerLlmsTxtRoute (mirrors the robots.txt pattern), wired in server/index.ts.
- Facts only: trade-up mechanics, float-exact pricing vs condition averages, data sources, chance-to-profit framing, explicit 'nothing is guaranteed.'
- Tests: llmstxt shape, differentiating facts, no-overclaim phrasing, and every linked URL must exist in the static sitemap (consistency guard).

## Verification
779 unit tests green, tsc clean. Frontend/SSR lane only — no engine/daemon/sync changes. Will verify live post-merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a public `/llms.txt` endpoint with a concise, machine-readable overview of TradeUpBot and its key pages.
  - Included supported marketplace references and core site information in the endpoint content.

- **Tests**
  - Added validation for formatting, factual claims, supported links, and avoidance of misleading guarantee language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->