### PR TITLE
fix(analytics): fire tradeup_view on main-table row expand

### DIFF
--- a/src/components/TradeUpTable.tsx
+++ b/src/components/TradeUpTable.tsx
@@ -7,6 +7,7 @@ import { OutcomeChart } from "./trade-up/OutcomeChart.js";
 import { InputList } from "./trade-up/InputList.js";
 import { OutcomeList } from "./trade-up/OutcomeList.js";
 import { VerifyResults } from "./trade-up/VerifyResults.js";
+import { trackEvent } from "../lib/analytics.js";
 
 interface VerifyResult {
   trade_up_id: number;
@@ -232,6 +233,7 @@ export function TradeUpTable({ tradeUps, sort, order, onSort, onNavigateSkin, on
   const handleExpand = useCallback(async (tuId: number) => {
     if (expandedId === tuId) { setExpandedId(null); return; }
     setExpandedId(tuId);
+    trackEvent("tradeup_view", { tradeup_id: String(tuId), location: "list" });
     // Load outcomes + inputs if not cached; results are keyed by trade-up id,
     // so a late response can never land in another row's state.
     const promises: Promise<void>[] = [];

--- a/tests/unit/tradeup-view-event.test.ts
+++ b/tests/unit/tradeup-view-event.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const tableSource = readFileSync(join(__dir, "../../src/components/TradeUpTable.tsx"), "utf-8");
+
+describe("tradeup_view instrumentation on the main table", () => {
+  it("fires tradeup_view when a row is expanded (not only on the share page)", () => {
+    expect(tableSource).toContain('trackEvent("tradeup_view"');
+  });
+
+  it("fires on expand only, inside handleExpand after the collapse early-return", () => {
+    const handler = tableSource.slice(tableSource.indexOf("const handleExpand"));
+    const collapseReturn = handler.indexOf("setExpandedId(null); return;");
+    const track = handler.indexOf('trackEvent("tradeup_view"');
+    expect(collapseReturn).toBeGreaterThan(-1);
+    expect(track).toBeGreaterThan(collapseReturn);
+  });
+
+  it("tags the event with the trade-up id and a list location", () => {
+    expect(tableSource).toMatch(/trackEvent\("tradeup_view", \{ tradeup_id: String\(tuId\), location: "list" \}\)/);
+  });
+});


### PR DESCRIPTION
## Why
First real GA4 funnel read (key events live since 7/20) showed **tradeup_view = 1 event in 28 days** vs 237 weekly views on /trade-ups. The event only fired on TradeUpSharePage — the core action (expanding a contract in the main table) was invisible, so page_view → tradeup_view → sign_up_start couldn't be measured.

## What
- `trackEvent("tradeup_view", { tradeup_id, location: "list" })` in `handleExpand`, after the collapse early-return (fires on expand only).
- `location` distinguishes list-expands from share-page views.
- Source-test pins: event present in the table, placed after the collapse return, correctly tagged.

## Verification
777 unit tests green, tsc clean. Frontend lane only.

Growth workstream: makes the engagement funnel readable; the interesting number next week is what % of list visitors ever open a contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking when a trade-up entry is expanded from the list, including the trade-up identifier and list location.

* **Tests**
  * Added coverage to verify that tracking occurs only when entries are expanded and includes the expected event details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->