### PR TITLE
feat(conversion): list-page pass — visible Details, expanded-row nudge, free-delay banner

### DIFF
--- a/server/routes/trade-ups.ts
+++ b/server/routes/trade-ups.ts
@@ -574,6 +574,7 @@ export function tradeUpsRouter(pool: pg.Pool): Router {
       page: pageNum,
       per_page: perPage,
       tier: effectiveTier,
+      signed_in: Boolean(req.user),
       tier_config: { delay: tierConfig.delay, limit: tierConfig.limit, showListingIds: tierConfig.showListingIds },
       my_claim_count: myClaimCount,
       claim_limit: effectiveTier === "pro" ? await getRateLimit(userId, "claim", 10) : null,

--- a/src/components/TradeUpTable.tsx
+++ b/src/components/TradeUpTable.tsx
@@ -8,6 +8,7 @@ import { InputList } from "./trade-up/InputList.js";
 import { OutcomeList } from "./trade-up/OutcomeList.js";
 import { VerifyResults } from "./trade-up/VerifyResults.js";
 import { trackEvent } from "../lib/analytics.js";
+import { authHref } from "../lib/ref.js";
 
 interface VerifyResult {
   trade_up_id: number;
@@ -40,6 +41,8 @@ interface Props {
   onNavigateCollection?: (collectionName: string) => void;
   onClaimChange?: (delta: number) => void;
   tier?: string;
+  /** false = anonymous visitor; gates the expanded-row Steam sign-in nudge */
+  signedIn?: boolean;
   showMyClaims?: boolean;
   claimLimit?: RateLimitInfo | null;
   verifyLimit?: RateLimitInfo | null;
@@ -173,7 +176,7 @@ function ClaimTimer({ expiresAt }: { expiresAt: string }) {
   );
 }
 
-export function TradeUpTable({ tradeUps, sort, order, onSort, onNavigateSkin, onNavigateCollection, onClaimChange, tier = "pro", showMyClaims = false, claimLimit, verifyLimit, onClaimLimitUpdate, onVerifyLimitUpdate, renderActions }: Props) {
+export function TradeUpTable({ tradeUps, sort, order, onSort, onNavigateSkin, onNavigateCollection, onClaimChange, tier = "pro", signedIn = true, showMyClaims = false, claimLimit, verifyLimit, onClaimLimitUpdate, onVerifyLimitUpdate, renderActions }: Props) {
   const { formatPrice } = useCurrency();
   const isFree = tier === "free";
   const isPro = tier === "pro" || tier === "admin";
@@ -315,6 +318,19 @@ export function TradeUpTable({ tradeUps, sort, order, onSort, onNavigateSkin, on
 
     return (
     <div className="bg-card">
+        {!signedIn && (
+          <div className="flex items-center justify-between gap-3 px-3 py-2 mb-3 bg-blue-950/30 border border-blue-500/30 rounded-md text-xs text-blue-200">
+            <span>Claim these listings before someone else does.</span>
+            <a
+              href={authHref(typeof window !== "undefined" ? window.location.pathname : "/trade-ups")}
+              rel="nofollow"
+              onClick={() => trackEvent("sign_up_start", { location: "expanded_row" })}
+              className="font-medium text-blue-400 hover:text-blue-300 whitespace-nowrap"
+            >
+              Sign in with Steam →
+            </a>
+          </div>
+        )}
       {renderActions ? (
         <div className="px-4 sm:px-5 py-2 border-b border-border/50 bg-muted/30">
           {renderActions(tu)}
@@ -555,7 +571,7 @@ export function TradeUpTable({ tradeUps, sort, order, onSort, onNavigateSkin, on
                   {age && <span className="text-[0.6rem] text-muted-foreground/40">{age}</span>}
                   {(claimedIds.has(tu.id)) && <span className="text-[0.6rem] text-purple-400">🔒</span>}
                   {tu.claimed_by_other && <span className="text-[0.6rem] text-muted-foreground">🔒</span>}
-                  <span className="text-muted-foreground/30 text-xs">{expandedId === tu.id ? "▼" : "▶"}</span>
+                  <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded border border-border text-[0.7rem] text-muted-foreground hover:text-foreground hover:border-foreground/40 transition-colors">Details<span className="text-[0.6rem]">{expandedId === tu.id ? "▼" : "▶"}</span></span>
                 </div>
               </div>
               {/* Collection badges */}
@@ -623,7 +639,7 @@ export function TradeUpTable({ tradeUps, sort, order, onSort, onNavigateSkin, on
                 onClick={() => handleExpand(tu.id)}
               >
                 <td className="px-3.5 py-2.5 border-b border-border/70">
-                  {expandedId === tu.id ? "\u25BC" : "\u25B6"}
+                  <span className="inline-flex items-center gap-1">Details<span className="text-[0.6rem]">{expandedId === tu.id ? "\u25BC" : "\u25B6"}</span></span>
                 </td>
                 <td className="px-3.5 py-2.5 border-b border-border/70">
                   {inputCount === 0 ? (

--- a/src/pages/TradeUpsPage.tsx
+++ b/src/pages/TradeUpsPage.tsx
@@ -47,6 +47,7 @@ export function TradeUpsPage({ types, defaultType, status, refreshKey, onNavigat
   const [total, setTotal] = useState(0);
   const [totalProfitable, setTotalProfitable] = useState(0);
   const [loading, setLoading] = useState(true); // Start loading to prevent empty state flash
+  const [signedIn, setSignedIn] = useState<boolean>(true); // optimistic: avoid nudge flash for signed-in users
   const [tier, setTier] = useState<string>(() => {
     // Persist tier to avoid "free tier" upgrade banner flash on mount
     if (typeof window !== "undefined") return localStorage.getItem("user_tier") || "free";
@@ -144,6 +145,7 @@ export function TradeUpsPage({ types, defaultType, status, refreshKey, onNavigat
       setTotalProfitable(data.total_profitable ?? 0);
       const newTier = data.tier || "free";
       setTier(newTier);
+      setSignedIn(Boolean(data.signed_in));
       try { localStorage.setItem("user_tier", newTier); } catch {}
       if (data.claim_limit) setClaimLimit(data.claim_limit);
       if (data.verify_limit) setVerifyLimit(data.verify_limit);
@@ -306,6 +308,9 @@ export function TradeUpsPage({ types, defaultType, status, refreshKey, onNavigat
         </div>
       ) : (
         <div className={loading ? "opacity-50 pointer-events-none transition-opacity" : "transition-opacity"}>
+          {isFree && !loading && (
+            <UpgradeBanner message="Free view: contracts are delayed 3 hours. Pro sees them the moment they're found." />
+          )}
           <TradeUpTable
             tradeUps={tradeUps}
             sort={sort}
@@ -314,16 +319,12 @@ export function TradeUpsPage({ types, defaultType, status, refreshKey, onNavigat
             onNavigateSkin={onNavigateSkin}
             onNavigateCollection={onNavigateCollection}
             tier={tier}
+            signedIn={signedIn}
             claimLimit={claimLimit}
             verifyLimit={verifyLimit}
             onClaimLimitUpdate={setClaimLimit}
             onVerifyLimitUpdate={setVerifyLimit}
           />
-
-          {/* Free tier: upgrade banner */}
-          {isFree && !loading && (
-            <UpgradeBanner message="Upgrade to Pro for real-time data, verification, and claims" />
-          )}
 
           {/* Pagination — all tiers */}
           {totalPages > 1 && (

--- a/tests/unit/list-conversion-pass.test.ts
+++ b/tests/unit/list-conversion-pass.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const table = readFileSync(join(__dir, "../../src/components/TradeUpTable.tsx"), "utf-8");
+const page = readFileSync(join(__dir, "../../src/pages/TradeUpsPage.tsx"), "utf-8");
+const api = readFileSync(join(__dir, "../../server/routes/trade-ups.ts"), "utf-8");
+
+describe("A: visible Details affordance", () => {
+  it("rows render a labeled Details control, not just a bare chevron", () => {
+    expect(table).toContain(">Details<");
+  });
+});
+
+describe("B: sign-up nudge in the expanded row", () => {
+  it("api exposes signed_in so the UI can distinguish anonymous from free-tier users", () => {
+    expect(api).toMatch(/signed_in: Boolean\(req\.user\)/);
+  });
+  it("expanded panel nudge fires sign_up_start tagged expanded_row and only for signed-out", () => {
+    expect(table).toContain('trackEvent("sign_up_start", { location: "expanded_row" })');
+    expect(table).toMatch(/\{!signedIn && \(/);
+    expect(table).toContain("authHref(");
+  });
+});
+
+describe("C: free-delay transparency banner above the table", () => {
+  it("names the concrete delay and links pricing", () => {
+    expect(page).toContain("delayed 3 hours");
+  });
+  it("renders before the table, not only after it", () => {
+    const bannerIdx = page.indexOf("delayed 3 hours");
+    const tableIdx = page.indexOf("<TradeUpTable");
+    expect(bannerIdx).toBeGreaterThan(-1);
+    expect(bannerIdx).toBeLessThan(tableIdx);
+  });
+});


### PR DESCRIPTION
## Why
Funnel (28d): 157 users → **11 ever expand a row** → 9 sign_up_start → 0 purchase. The leak is the list page, not the homepage. Tim approved A+B+C on 2026-07-29.

## What
- **A** Labeled `Details` control on rows (desktop+mobile) — the bare chevron made expandability invisible.
- **B** Signed-out visitors get a Steam sign-in nudge inside the expanded panel (highest-intent moment), tracked `sign_up_start {location:'expanded_row'}`. `/api/trade-ups` now returns `signed_in` (additive; anonymous vs free-tier was indistinguishable client-side); threaded as `signedIn` prop.
- **C** Upgrade banner moved above the table, copy now states the concrete fact: 'Free view: contracts are delayed 3 hours. Pro sees them the moment they're found.'

## Verification
800 unit + 209 integration green (one flaky claims test passed on re-run) · tsc clean · build + SEO verify green.

## Measurement (by 8/10)
Expand-rate (tradeup_view/users) and sign_up_start share by location, weekly snapshot. All changes reversible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sign-in prompts for anonymous users when viewing expanded trade-up details.
  * Added labeled “Details” controls with clearer expand/collapse states on desktop and mobile.
  * Added a free-tier notice explaining that contract data may be delayed by three hours.

* **Bug Fixes**
  * Improved sign-in status handling to prevent unnecessary prompts for authenticated users.

* **Tests**
  * Added coverage for sign-in prompts, details controls, authentication status, and the free-tier transparency notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->