### PR TITLE
It14: remove dead E2 greedy selection path

### DIFF
--- a/server/engine/discovery.ts
+++ b/server/engine/discovery.ts
@@ -298,9 +298,9 @@ export async function findProfitableTradeUps(
 
     console.log(`  ${colIds.length} eligible collections, ${allAdjusted.length} listings`);
 
-    // E3 knapsack telemetry (per rarity): how often the boundary-knapsack finds
-    // a feasible set, and how often it recovers one the price-greedy missed —
-    // the direct measure of E3's unique coverage.
+    // Boundary-knapsack telemetry: feasible hits across E2 and Steps 1-2.
+    // Recoveries count every knapsack-only E2 hit plus Step 1-2 hits whose
+    // price-greedy candidate was null.
     let knapsackAttempts = 0;
     let knapsackHits = 0;
     let knapsackRecovered = 0;
@@ -602,9 +602,8 @@ export async function findProfitableTradeUps(
     // the explore strategies. E2's value-first boundary targeting supersedes
     // its thesis. See .monitoring/autoresearch-log.md, 2026-07-17.)
 
-    // E3 telemetry: does the boundary-knapsack ever fire, and does it recover
-    // feasible sets the greedy missed? (Worker path has no onProgress → console.)
-    console.log(`  ${inputRarity}: knapsack ${knapsackHits}/${knapsackAttempts} feasible, ${knapsackRecovered} greedy-null recoveries`);
+    // Recovery semantics: all E2 hits plus Step 1-2 greedy-null hits.
+    console.log(`  ${inputRarity}: knapsack ${knapsackHits}/${knapsackAttempts} feasible, ${knapsackRecovered} recoveries (E2 hits + S1/S2 greedy-null)`);
 
     options.onProgress?.(
       `${inputRarity}: done (${store.total} trade-ups, ${store.getSignatureCount()} signatures)`,

--- a/server/engine/discovery.ts
+++ b/server/engine/discovery.ts
@@ -3,7 +3,7 @@ import {
   floatToCondition,
   type TradeUp,
 } from "../../shared/types.js";
-import type { DbSkinOutcome, ListingWithCollection } from "./types.js";
+import type { AdjustedListing, DbSkinOutcome, ListingWithCollection } from "./types.js";
 import { EXCLUDED_COLLECTIONS, CONDITION_BOUNDS } from "./types.js";
 import { buildPriceCache, priceCache as globalPriceCache } from "./pricing.js";
 import { getOutcomesForCollections, getNextRarity, loadDiscoveryData, buildWeightedPool } from "./data-load.js";
@@ -108,6 +108,19 @@ export function enumerateBoundaryTargets(
       (a.collectionId < b.collectionId ? -1 : a.collectionId > b.collectionId ? 1 : 0)
   );
   return targets.slice(0, Math.max(0, k));
+}
+
+/**
+ * Select one E2 reverse-boundary candidate. Production provenance showed the
+ * price-greedy candidate never minted an E2 contract, so this path evaluates
+ * only the feasibility-complete boundary-knapsack result.
+ */
+export function selectE2Target(
+  byColAdj: Map<string, AdjustedListing[]>,
+  quotas: Map<string, number>,
+  adjTarget: number,
+): AdjustedListing[] | null {
+  return selectKnapsackUnderBoundary(byColAdj, quotas, adjTarget);
 }
 
 /** Per-strategy yield stats from exploration. */
@@ -314,16 +327,12 @@ export async function findProfitableTradeUps(
         const outcomes = outcomesForCols(t.collectionId);
         if (outcomes.length === 0) continue;
         const quotas = new Map([[t.collectionId, 10]]);
-        const greedy = selectForFloatTarget(byColAdj, quotas, t.adjTarget);
-        if (greedy) {
-          await tryEval(greedy, outcomes, "e2:greedy");
-          e2Evals++;
-        }
+        const knapsack = selectE2Target(byColAdj, quotas, t.adjTarget);
         knapsackAttempts++;
-        const knapsack = selectKnapsackUnderBoundary(byColAdj, quotas, t.adjTarget);
         if (knapsack) {
           knapsackHits++;
-          if (!greedy) knapsackRecovered++;
+          // With no greedy E2 candidate, every hit is now a recovery.
+          knapsackRecovered++;
           await tryEval(knapsack, outcomes, "e2:knapsack");
           e2Evals++;
         }

--- a/tests/unit/discovery-e2.test.ts
+++ b/tests/unit/discovery-e2.test.ts
@@ -9,8 +9,9 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { enumerateBoundaryTargets, E2_MAX_TARGETS } from "../../server/engine/discovery.js";
-import { makeOutcome } from "../helpers/fixtures.js";
+import { enumerateBoundaryTargets, E2_MAX_TARGETS, selectE2Target } from "../../server/engine/discovery.js";
+import { selectForFloatTarget, selectKnapsackUnderBoundary } from "../../server/engine/selection.js";
+import { makeAdjustedListing, makeOutcome } from "../helpers/fixtures.js";
 import type { DbSkinOutcome } from "../../server/engine/types.js";
 
 // CONDITION_BOUNDS boundaries: FN max 0.07, MW max 0.15, FT max 0.38, WW max 0.45
@@ -117,5 +118,55 @@ describe("enumerateBoundaryTargets (E2)", () => {
     }
     const targets = enumerateBoundaryTargets(byCol(...cols), priceOf);
     expect(targets).toHaveLength(E2_MAX_TARGETS);
+  });
+});
+
+describe("selectE2Target", () => {
+  it("returns only the deterministic knapsack candidate when greedy finds a dominated set", () => {
+    const pool = [
+      0.75, 0.25, 0.625, 0.75, 0.75, 1,
+      0.625, 1, 0.625, 0.625, 0.125, 0.375,
+    ].map((adjustedFloat, index) => makeAdjustedListing({
+      id: `listing-${index}`,
+      collection_id: "col-e2",
+      price_cents: (index + 1) * 100,
+      adjustedFloat,
+    }));
+    const quotas = new Map([["col-e2", 10]]);
+    const byColAdj = new Map([["col-e2", pool]]);
+
+    const greedy = selectForFloatTarget(byColAdj, quotas, 0.625);
+    const knapsack = selectKnapsackUnderBoundary(byColAdj, quotas, 0.625);
+    const selected = selectE2Target(byColAdj, quotas, 0.625);
+
+    expect(greedy).not.toBeNull();
+    expect(knapsack).not.toBeNull();
+    expect(selected).toEqual(knapsack);
+    expect(selected).not.toEqual(greedy);
+    expect(selected!.reduce((sum, item) => sum + item.price_cents, 0))
+      .toBeLessThan(greedy!.reduce((sum, item) => sum + item.price_cents, 0));
+    expect(selected!.reduce((sum, item) => sum + item.adjustedFloat, 0))
+      .toBeLessThan(greedy!.reduce((sum, item) => sum + item.adjustedFloat, 0));
+
+    const reversed = selectE2Target(
+      new Map([["col-e2", [...pool].reverse()]]),
+      quotas,
+      0.625,
+    );
+    expect(reversed).toEqual(selected);
+  });
+
+  it("returns null when the knapsack selector cannot satisfy the quota", () => {
+    const pool = Array.from({ length: 9 }, (_, index) => makeAdjustedListing({
+      id: `listing-${index}`,
+      collection_id: "col-e2",
+      adjustedFloat: 0.01,
+    }));
+
+    expect(selectE2Target(
+      new Map([["col-e2", pool]]),
+      new Map([["col-e2", 10]]),
+      0.1,
+    )).toBeNull();
   });
 });


### PR DESCRIPTION
Autoresearch Iteration 14 per the operating contract (pre-approved GO from the It13 investigation): the E2 greedy selection path has produced zero rows ever in production (verified live 2026-08-09: e2:greedy total=0; e2:knapsack 26 active), so it is removed.

- Extract `selectE2Target` as a testable seam with unit tests (deterministic knapsack dominance + null/quota-unsatisfied boundary)
- Remove the E2 `selectForFloatTarget` call and `tryEval(..., "e2:greedy")`; repo is grep-clean for `e2:greedy`
- Make `knapsackRecovered++` unconditional on E2 knapsack hits; telemetry wording updated
- E2 cap unchanged at 32; frozen trade_up_score formula and pricing untouched

Verification: typecheck clean; unit 802/802 (79 files); integration 209/209 (28 files). Adversarial review r1: approved, 0 blockers, 3 nits (recorded).

Production baseline pre-It14 (read-only): daemon online, deployed head 390d656, M1=48, M2=30.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved E2 target selection to consistently choose feasible combinations within configured boundaries.
  * Prevented price-greedy choices from overriding better valid selections.
  * Improved recovery tracking and reporting for qualifying selections.

* **Tests**
  * Added coverage for deterministic selection, lower-cost outcomes, input-order independence, and unsatisfied quota scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->