### PR TITLE
It15: S20 deep-rank swap exploration strategy

### DIFF
--- a/server/daemon/adaptive-weights.ts
+++ b/server/daemon/adaptive-weights.ts
@@ -188,11 +188,11 @@ export function formatYieldSummary(
 /** Strategy counts per tier type. */
 export const STRATEGY_COUNTS: Record<string, number> = {
   knife: 17,
-  classified: 20,
-  restricted: 20,
-  milspec: 20,
-  industrial: 20,
-  consumer: 20,
+  classified: 21,   // It15: S20 deep-rank swap
+  restricted: 21,
+  milspec: 21,
+  industrial: 21,
+  consumer: 21,
 };
 
 /** Float-biased strategy indices per tier (used as fallback). */

--- a/server/engine/discovery.ts
+++ b/server/engine/discovery.ts
@@ -123,6 +123,59 @@ export function selectE2Target(
   return selectKnapsackUnderBoundary(byColAdj, quotas, adjTarget);
 }
 
+/** One input row of a swap-pool trade-up (inputs sorted most-expensive-first). */
+export interface SwapPoolInput {
+  listing_id: string;
+  skin_name: string;
+  collection_id: string;
+  price_cents: number;
+}
+
+/**
+ * S20 — deep-rank swap (It15). S10 mutates the most expensive input (rank 0)
+ * of a known-profitable trade-up and S16 the second (rank 1); production
+ * provenance shows these two mutations mint nearly every score>=50 contract,
+ * with S16 out-yielding S10 5-8x. Ranks 2..8 were never mutated by any
+ * strategy. This helper generalizes the mutation: replace the input at `rank`
+ * with a cheaper, unused, same-collection listing drawn from the 20 cheapest
+ * alternatives (byCollection lists are price-ascending), mirroring S10/S16.
+ *
+ * Returns the reconstructed full input set, or null when the rank is out of
+ * range, no cheaper alternative exists, or a non-swapped listing can no
+ * longer be found in `allListings` (stale swap-pool row).
+ */
+export function swapInputAtRank(
+  inputs: SwapPoolInput[],
+  rank: number,
+  byCollection: Map<string, ListingWithCollection[]>,
+  allListings: ListingWithCollection[],
+  rng: () => number = Math.random,
+): ListingWithCollection[] | null {
+  if (rank < 0 || rank >= inputs.length) return null;
+  const target = inputs[rank];
+
+  const colListings = byCollection.get(target.collection_id);
+  if (!colListings || colListings.length < 2) return null;
+
+  const cheaper = colListings.filter(l =>
+    l.price_cents < target.price_cents &&
+    l.id !== target.listing_id &&
+    !inputs.some(inp => inp.listing_id === l.id)
+  );
+  if (cheaper.length === 0) return null;
+
+  const pool = cheaper.slice(0, 20);
+  const replacement = pool[Math.floor(rng() * pool.length)];
+
+  const reconstructed: ListingWithCollection[] = [];
+  for (const inp of inputs) {
+    const wanted = inp.listing_id === target.listing_id ? replacement.id : inp.listing_id;
+    const found = allListings.find(l => l.id === wanted);
+    if (found) reconstructed.push(found);
+  }
+  return reconstructed.length === inputs.length ? reconstructed : null;
+}
+
 /** Per-strategy yield stats from exploration. */
 export interface StrategyYieldEntry {
   strategyId: number;
@@ -1157,7 +1210,7 @@ export async function exploreWithBudget(
   }
 
   // Load profitable trade-ups + inputs for swap optimization (1 query total)
-  const swapPool: { id: number; inputs: { listing_id: string; skin_name: string; collection_id: string; price_cents: number }[] }[] = [];
+  const swapPool: { id: number; inputs: SwapPoolInput[] }[] = [];
   try {
     const { rows: profInputs } = await pool.query(`
       SELECT tu.id as trade_up_id, tui.listing_id, tui.skin_name,
@@ -1222,7 +1275,7 @@ export async function exploreWithBudget(
   // High-float bias: strategies 0 (random pair+offset), 2 (condition-pure) — targets WW/BS outputs
   // Strategy 15 (underpriced+filler) gets 3x weight via FLOAT_BIASED_CASES
   const FLOAT_BIASED_CASES = options.preferHighFloat ? [0, 2] : [5, 7, 8, 12, 13, 15, 15];
-  const TOTAL_STRATEGIES = 20;
+  const TOTAL_STRATEGIES = 21; // It15: S20 deep-rank swap
   const adaptiveWeights = options.strategyWeights?.length === TOTAL_STRATEGIES ? options.strategyWeights : undefined;
 
   const results: TradeUp[] = [];
@@ -1712,6 +1765,18 @@ export async function exploreWithBudget(
           }
           break;
         }
+
+        case 20: {
+          // S20 (It15) — deep-rank swap: S10/S16 mutate ranks 0/1 of profitable
+          // trade-ups and mint nearly all score>=50 contracts; ranks 2..8 were
+          // unexplored. Swap a uniformly random deep-rank input for a cheaper
+          // same-collection listing.
+          if (swapPool.length === 0) break;
+          const tu = pick(swapPool);
+          const rank = 2 + Math.floor(Math.random() * 7); // ranks 2..8
+          inputs = swapInputAtRank(tu.inputs, rank, byCollection, allListings);
+          break;
+        }
       }
 
       // Curve-aware override: swap listing source based on output curve shape
@@ -1735,8 +1800,11 @@ export async function exploreWithBudget(
               inputs = repicked.slice(0, 10);
             }
           }
-          // If curve says price-sort but we used value-ratio, re-pick from byCollection
-          if (useValue === false && strategy >= 12) {
+          // If curve says price-sort but we used value-ratio, re-pick from byCollection.
+          // S20 is exempt: it is already price-sorted (a deep-rank swap of a profitable
+          // trade-up), and replacing its inputs here would tag generic re-picks with
+          // explore:S20, contaminating the lever's provenance measurement (It15).
+          if (useValue === false && strategy >= 12 && strategy !== 20) {
             const repicked = usedCols.flatMap(c => (byCollection.get(c) ?? []).slice(0, 5));
             if (repicked.length >= 10) {
               repicked.sort((a, b) => a.price_cents - b.price_cents);

--- a/tests/unit/adaptive-weights.test.ts
+++ b/tests/unit/adaptive-weights.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Adaptive strategy weights — strategy-count contract (It15).
+ *
+ * Gun tiers gained S20 (deep-rank swap), moving TOTAL_STRATEGIES 20 → 21.
+ * Persisted yield histories in sync_meta still hold 20 entries, so
+ * computeAdaptiveWeights must tolerate a shorter history: the padded new
+ * strategy is treated exactly like a dead strategy (0-yield softmax share,
+ * ~1.8% opening allocation on a production-shaped history — NOT the 0.1%
+ * MIN_FLOOR, which only binds when the softmax share falls below it) until
+ * it earns signal.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  computeAdaptiveWeights,
+  STRATEGY_COUNTS,
+  FLOAT_BIASED_BY_TIER,
+  type YieldHistory,
+} from "../../server/daemon/adaptive-weights.js";
+
+describe("STRATEGY_COUNTS (It15 S20 bump)", () => {
+  it("gun tiers advertise 21 strategies, knife stays at 17", () => {
+    expect(STRATEGY_COUNTS.classified).toBe(21);
+    expect(STRATEGY_COUNTS.restricted).toBe(21);
+    expect(STRATEGY_COUNTS.milspec).toBe(21);
+    expect(STRATEGY_COUNTS.industrial).toBe(21);
+    expect(STRATEGY_COUNTS.consumer).toBe(21);
+    expect(STRATEGY_COUNTS.knife).toBe(17);
+  });
+});
+
+describe("computeAdaptiveWeights with a shorter persisted history", () => {
+  it("pads a 20-entry history to 21 weights, treating the new strategy as dead", () => {
+    // History shaped like production classified: S16 dominates, S10 second.
+    const strategies = Array.from({ length: 20 }, (_, s) => {
+      if (s === 16) return { iterations: 4000, profitable: 14 };
+      if (s === 10) return { iterations: 2000, profitable: 2 };
+      return { iterations: 100, profitable: 0 };
+    });
+    const history: YieldHistory = { strategies, lastUpdated: new Date().toISOString() };
+
+    const weights = computeAdaptiveWeights(history, 21, FLOAT_BIASED_BY_TIER.classified);
+
+    expect(weights).toHaveLength(21);
+    // every strategy keeps a positive weight (floor)
+    for (const w of weights) expect(w).toBeGreaterThan(0);
+    // the untested new strategy stays below the proven top strategies
+    expect(weights[20]).toBeLessThan(weights[16]);
+    expect(weights[20]).toBeLessThan(weights[10]);
+    // padding is exactly the dead-strategy treatment: same weight as a
+    // 0-yield strategy that has real iteration history (S0: 100 iters, 0 hits)
+    expect(weights[20]).toBe(weights[0]);
+  });
+});

--- a/tests/unit/discovery-swap.test.ts
+++ b/tests/unit/discovery-swap.test.ts
@@ -1,0 +1,164 @@
+/**
+ * S20 — deep-rank swap (It15): pure unit tests for swapInputAtRank.
+ *
+ * S10 swaps the most expensive input (rank 0) of a known-profitable trade-up
+ * and S16 the second-most-expensive (rank 1); S16 out-yields S10 5-8x in
+ * production. Ranks 2..8 were never mutated by any strategy. swapInputAtRank
+ * generalizes the mutation: replace the input at `rank` (inputs sorted
+ * most-expensive-first) with a cheaper, unused, same-collection listing drawn
+ * from the 20 cheapest alternatives — mirroring the S10/S16 candidate pool.
+ */
+
+import { describe, it, expect } from "vitest";
+import { swapInputAtRank } from "../../server/engine/discovery.js";
+import type { SwapPoolInput } from "../../server/engine/discovery.js";
+import { makeListing } from "../helpers/fixtures.js";
+import type { ListingWithCollection } from "../../server/engine/types.js";
+
+const COL = "col-A";
+
+/** 10 input listings sorted most-expensive-first: 1000, 900, ..., 100 cents. */
+function makeTradeUpListings(): ListingWithCollection[] {
+  return Array.from({ length: 10 }, (_, i) =>
+    makeListing({
+      id: `input-${i}`,
+      collection_id: COL,
+      price_cents: 1000 - i * 100,
+    })
+  );
+}
+
+function asInputs(listings: ListingWithCollection[]): SwapPoolInput[] {
+  return listings.map(l => ({
+    listing_id: l.id,
+    skin_name: l.skin_name,
+    collection_id: l.collection_id,
+    price_cents: l.price_cents,
+  }));
+}
+
+/** Collection map is price-ascending, like loadDiscoveryData's byCollection. */
+function buildByCollection(listings: ListingWithCollection[]): Map<string, ListingWithCollection[]> {
+  const map = new Map<string, ListingWithCollection[]>();
+  for (const l of [...listings].sort((a, b) => a.price_cents - b.price_cents)) {
+    const list = map.get(l.collection_id) ?? [];
+    list.push(l);
+    map.set(l.collection_id, list);
+  }
+  return map;
+}
+
+describe("swapInputAtRank (S20)", () => {
+  it("replaces exactly the rank-th input with a cheaper unused same-collection listing", () => {
+    const tuListings = makeTradeUpListings();
+    const inputs = asInputs(tuListings);
+    // rank 2 costs 800; one cheaper alternative at 750
+    const alt = makeListing({ id: "alt-0", collection_id: COL, price_cents: 750 });
+    const all = [...tuListings, alt];
+
+    const result = swapInputAtRank(inputs, 2, buildByCollection(all), all, () => 0);
+
+    expect(result).not.toBeNull();
+    expect(result!).toHaveLength(10);
+    const ids = result!.map(l => l.id);
+    expect(ids).not.toContain("input-2");
+    // all other 9 inputs preserved
+    for (let i = 0; i < 10; i++) {
+      if (i !== 2) expect(ids).toContain(`input-${i}`);
+    }
+    const replacement = result!.find(l => !l.id.startsWith("input-"))!;
+    expect(replacement.price_cents).toBeLessThan(800);
+    expect(replacement.collection_id).toBe(COL);
+  });
+
+  it("never picks a listing already used by the trade-up", () => {
+    const tuListings = makeTradeUpListings();
+    const inputs = asInputs(tuListings);
+    // The only listings cheaper than rank 2 (800) are inputs 3..9 themselves.
+    const result = swapInputAtRank(inputs, 2, buildByCollection(tuListings), tuListings, () => 0);
+    expect(result).toBeNull();
+  });
+
+  it("rejects more-expensive alternatives, including when no cheaper candidate exists", () => {
+    const tuListings = makeTradeUpListings();
+    const inputs = asInputs(tuListings);
+    // Only unused non-input alternatives: one MORE expensive than rank 2 (800),
+    // one cheaper. The expensive one must never be chosen.
+    const expensive = makeListing({ id: "alt-expensive", collection_id: COL, price_cents: 950 });
+    const cheap = makeListing({ id: "alt-cheap", collection_id: COL, price_cents: 750 });
+    const all = [...tuListings, expensive, cheap];
+    const byCol = buildByCollection(all);
+
+    // rng sweep: the replacement is always the cheaper candidate
+    for (const r of [0, 0.5, 0.9999]) {
+      const result = swapInputAtRank(inputs, 2, byCol, all, () => r);
+      expect(result).not.toBeNull();
+      const replacement = result!.find(l => l.id.startsWith("alt-"))!;
+      expect(replacement.id).toBe("alt-cheap");
+      expect(replacement.price_cents).toBeLessThan(800);
+    }
+
+    // An unused but MORE expensive candidate alone never qualifies:
+    // rank 9 (cheapest input) has no cheaper alternative -> null.
+    const allExpensiveOnly = [...tuListings, expensive];
+    const resultNone = swapInputAtRank(inputs, 9, buildByCollection(allExpensiveOnly), allExpensiveOnly, () => 0);
+    expect(resultNone).toBeNull();
+  });
+
+  it("returns null for out-of-range ranks", () => {
+    const tuListings = makeTradeUpListings();
+    const inputs = asInputs(tuListings);
+    const alt = makeListing({ id: "alt-0", collection_id: COL, price_cents: 50 });
+    const all = [...tuListings, alt];
+    const byCol = buildByCollection(all);
+    expect(swapInputAtRank(inputs, -1, byCol, all)).toBeNull();
+    expect(swapInputAtRank(inputs, 10, byCol, all)).toBeNull();
+  });
+
+  it("returns null when the target has no cheaper alternative", () => {
+    const tuListings = makeTradeUpListings();
+    const inputs = asInputs(tuListings);
+    // rank 9 is the cheapest listing in the collection — nothing cheaper exists
+    const result = swapInputAtRank(inputs, 9, buildByCollection(tuListings), tuListings, () => 0);
+    expect(result).toBeNull();
+  });
+
+  it("draws only from the 20 cheapest alternatives", () => {
+    const tuListings = makeTradeUpListings();
+    const inputs = asInputs(tuListings);
+    // 30 alternatives cheaper than rank 2 (800): 10, 20, ..., 300 cents
+    const alts = Array.from({ length: 30 }, (_, i) =>
+      makeListing({ id: `alt-${i}`, collection_id: COL, price_cents: 10 + i * 10 })
+    );
+    const all = [...tuListings, ...alts];
+    // rng near 1 picks the last pool slot: index 19 of the 20 cheapest
+    const result = swapInputAtRank(inputs, 2, buildByCollection(all), all, () => 0.9999);
+    expect(result).not.toBeNull();
+    const replacement = result!.find(l => l.id.startsWith("alt-"))!;
+    expect(replacement.id).toBe("alt-19");
+  });
+
+  it("returns null when a non-swapped input cannot be reconstructed from allListings", () => {
+    const tuListings = makeTradeUpListings();
+    const inputs = asInputs(tuListings);
+    const alt = makeListing({ id: "alt-0", collection_id: COL, price_cents: 750 });
+    // input-7 missing from allListings — stale swap-pool row
+    const all = [...tuListings.filter(l => l.id !== "input-7"), alt];
+    const result = swapInputAtRank(inputs, 2, buildByCollection(all), all, () => 0);
+    expect(result).toBeNull();
+  });
+
+  it("is deterministic under an injected rng", () => {
+    const tuListings = makeTradeUpListings();
+    const inputs = asInputs(tuListings);
+    const alts = Array.from({ length: 5 }, (_, i) =>
+      makeListing({ id: `alt-${i}`, collection_id: COL, price_cents: 100 + i * 50 })
+    );
+    const all = [...tuListings, ...alts];
+    const byCol = buildByCollection(all);
+    const a = swapInputAtRank(inputs, 3, byCol, all, () => 0.5);
+    const b = swapInputAtRank(inputs, 3, byCol, all, () => 0.5);
+    expect(a).not.toBeNull();
+    expect(a!.map(l => l.id)).toEqual(b!.map(l => l.id));
+  });
+});


### PR DESCRIPTION
## Lever (autoresearch It15)

Production provenance shows `explore:S10` (swap most-expensive input) and `explore:S16` (swap second-most-expensive) mint 62 of the 63 active score>=50 contracts, with S16 out-yielding S10 5-8x. Ranks 2..8 of the profitable swap pool were never mutated by any strategy.

## Change
- New pure helper `swapInputAtRank` (rng-injectable) + `SwapPoolInput` in `server/engine/discovery.ts`.
- New strategy case 20: swap a uniformly random rank-2..8 input of a swap-pool trade-up for a cheaper unused same-collection listing from the 20 cheapest alternatives (mirrors the S10/S16 candidate pool).
- S20 exempt from the curve-aware price-sort re-pick so `explore:S20` provenance measures only the deep-rank swap.
- `TOTAL_STRATEGIES` 20->21; gun-tier `STRATEGY_COUNTS` 20->21 (knife stays 17). Persisted 20-entry yield histories pad safely (tested).

## Bounds
S20 opens at ~1.8% of gun-tier explore allocation (dead-strategy softmax share) and only grows on earned yield; S0-S19 and the shared eval path are untouched. No pricing, score-formula, rate-limit, or migration changes.

## Gates
- typecheck, 812 unit, 209 integration (tradeupbot_test) — green
- Adversarial review R1: SHIP, 0 blockers (6 NITs; the 3 substantive ones addressed)
- Adversarial review R2 on the delta: SHIP, 0 blockers

## Baseline (pre-deploy, 2026-08-14 ~10:52 UTC)
M1(top100 median)=50, ge50=63, ge10=5014, explore:S20 rows=0 (all statuses), active=546438, avg cycle 33.4 min.

## Watch items / revert signal
- S20 appears in gun-tier yield telemetry; first `explore:S20` rows over the stabilization window; cycle time and M1/M2 not regressing.
- Revert on any attributable crash/OOM/restart-loop/DB error/cadence failure.

Daemon/engine code changed: after merge deploy, clear /root/.cache/tsx and `pm2 restart daemon`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a 21st exploration strategy for gun-tier trade-ups.
  * Introduced deep-rank swaps that can replace selected inputs with cheaper, unused items from the same collection.
  * Added safeguards for invalid, stale, unavailable, or unsuitable swap candidates.
* **Bug Fixes**
  * Improved adaptive weighting so the new strategy is included when restoring shorter strategy histories.
* **Tests**
  * Added coverage for strategy weighting and deep-rank swap behavior, including deterministic selection and candidate limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->